### PR TITLE
Add OBS toggle recording action

### DIFF
--- a/src/renderer/actions/ActionSaveReplayBuffer.tsx
+++ b/src/renderer/actions/ActionSaveReplayBuffer.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { ActionTypeGenerator, Context } from "@vinceau/event-actions";
 import { produce } from "immer";
 
-import { DelayInput, InlineDropdown } from "@/components/Misc/InlineInputs";
+import { DelayInput, NotifyInput } from "@/components/Misc/InlineInputs";
 import { delay as waitMillis, notify as sendNotification, parseSecondsDelayValue } from "@/lib/utils";
 import { ActionComponent } from "./types";
 
@@ -76,22 +76,7 @@ const ReplayBufferInput = (props: ReplayBufferInputProps) => {
                 {"Save the OBS replay buffer after a "}
                 <DelayInput value={value.delaySeconds} onChange={onDelayChange} placeholder={`${DEFAULT_DELAY_SECONDS}`} />
                 {" second delay and "}
-                <InlineDropdown
-                    value={Boolean(value.notify)}
-                    onChange={onNotifyChange}
-                    options={[
-                        {
-                            key: "notify-me",
-                            value: true,
-                            text: "notify",
-                        },
-                        {
-                            key: "dont-notify-me",
-                            value: false,
-                            text: "don't notify",
-                        },
-                    ]}
-                />
+                <NotifyInput value={value.notify} onChange={onNotifyChange} />
                 {" me about it"}
             </div>
         </div>

--- a/src/renderer/actions/ActionSaveReplayBuffer.tsx
+++ b/src/renderer/actions/ActionSaveReplayBuffer.tsx
@@ -22,7 +22,7 @@ interface ActionSaveReplayBufferParams {
 const defaultParams = (): ActionSaveReplayBufferParams => {
     return {
         delaySeconds: DEFAULT_DELAY_SECONDS.toString(),
-        notify: true,
+        notify: false,
     };
 };
 

--- a/src/renderer/actions/ActionSaveReplayBuffer.tsx
+++ b/src/renderer/actions/ActionSaveReplayBuffer.tsx
@@ -4,7 +4,7 @@ import { ActionTypeGenerator, Context } from "@vinceau/event-actions";
 import { produce } from "immer";
 
 import { DelayInput, InlineDropdown } from "@/components/Misc/InlineInputs";
-import { delay as waitMillis, notify as sendNotification } from "@/lib/utils";
+import { delay as waitMillis, notify as sendNotification, parseSecondsDelayValue } from "@/lib/utils";
 import { ActionComponent } from "./types";
 
 import { CustomIcon } from "@/components/Misc/Misc";
@@ -26,18 +26,10 @@ const defaultParams = (): ActionSaveReplayBufferParams => {
     };
 };
 
-const parseDelayValue = (delay?: string): number => {
-    let seconds = parseInt(delay || DEFAULT_DELAY_SECONDS.toString(), 10);
-    if (isNaN(seconds)) {
-        seconds = DEFAULT_DELAY_SECONDS;
-    }
-    return seconds;
-};
-
 const actionSaveBuffer: ActionTypeGenerator = (params: ActionSaveReplayBufferParams) => {
     return async (ctx: Context): Promise<Context> => {
         try {
-            const seconds = parseDelayValue(params.delaySeconds);
+            const seconds = parseSecondsDelayValue(DEFAULT_DELAY_SECONDS, params.delaySeconds);
             if (seconds > 0) {
                 await waitMillis(seconds * 1000);
             }

--- a/src/renderer/actions/ActionSaveReplayBuffer.tsx
+++ b/src/renderer/actions/ActionSaveReplayBuffer.tsx
@@ -39,7 +39,7 @@ const actionSaveBuffer: ActionTypeGenerator = (params: ActionSaveReplayBufferPar
             }
         } catch (err) {
             console.error(err);
-            sendNotification("Failed to save replay buffer. Is replay buffer on?");
+            sendNotification("Failed to save Replay Buffer. Is Replay Buffer on and a Save Replay Buffer hotkey assigned?");
         }
         return ctx;
     };

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -78,7 +78,7 @@ const actionToggleRecording: ActionTypeGenerator = (params: ActionToggleRecordin
             }
         } catch (err) {
             console.error(err);
-            notify(`Could not ${obsRecordingLabel(params.recordAction)} OBS recording. Are you connected to OBS?`);
+            notify(`Failed to ${obsRecordingLabel(params.recordAction)} OBS recording: ${err.error}`);
         }
         return ctx;
     };

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -5,7 +5,7 @@ import { produce } from "immer";
 import { useSelector } from "react-redux";
 import { Button } from "semantic-ui-react";
 
-import { DelayInput, InlineDropdown } from "@/components/Misc/InlineInputs";
+import { DelayInput, InlineDropdown, NotifyInput } from "@/components/Misc/InlineInputs";
 import { CustomIcon } from "@/components/Misc/Misc";
 import { connectToOBSAndNotify, getAllSceneItems, setRecordingState, OBSRecordingAction } from "@/lib/obs";
 import { delay as waitMillis, notify, parseSecondsDelayValue, capitalize } from "@/lib/utils";
@@ -114,7 +114,9 @@ const RecordingNameInput = (props: { value: ActionToggleRecordingParams, onChang
                 />
                 {" the OBS recording after a "}
                 <DelayInput value={value.delaySeconds} onChange={onDelayChange} placeholder={`${DEFAULT_DELAY_SECONDS}`} />
-                {" second delay"}
+                {" second delay and "}
+                <NotifyInput value={value.notify} onChange={onNotifyChange} />
+                {" me about it"}
             </div>
         </div>
     );

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -2,14 +2,11 @@ import * as React from "react";
 
 import { ActionTypeGenerator, Context } from "@vinceau/event-actions";
 import { produce } from "immer";
-import { useSelector } from "react-redux";
-import { Button } from "semantic-ui-react";
 
 import { DelayInput, InlineDropdown, NotifyInput } from "@/components/Misc/InlineInputs";
 import { CustomIcon } from "@/components/Misc/Misc";
-import { connectToOBSAndNotify, getAllSceneItems, OBSRecordingAction, setRecordingState } from "@/lib/obs";
+import { OBSRecordingAction, setRecordingState } from "@/lib/obs";
 import { capitalize, delay as waitMillis, notify, parseSecondsDelayValue } from "@/lib/utils";
-import { iRootState } from "@/store";
 import { ActionComponent } from "./types";
 
 import obsIcon from "@/styles/images/obs.svg";

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -21,10 +21,6 @@ const obsRecordingLabel = (action: OBSRecordingAction): string => {
             return "start";
         case OBSRecordingAction.STOP:
             return "stop";
-        case OBSRecordingAction.PAUSE:
-            return "pause";
-        case OBSRecordingAction.UNPAUSE:
-            return "unpause";
         default:
             console.error(`Unknown OBS action: ${action}`);
             return "";
@@ -39,10 +35,6 @@ const pastObsRecordingLabel = (action: OBSRecordingAction): string => {
             return "started";
         case OBSRecordingAction.STOP:
             return "stopped";
-        case OBSRecordingAction.PAUSE:
-            return "paused";
-        case OBSRecordingAction.UNPAUSE:
-            return "unpaused";
         default:
             console.error(`Unknown OBS action: ${action}`);
             return "";
@@ -53,8 +45,6 @@ const recordActions = [
     OBSRecordingAction.TOGGLE,
     OBSRecordingAction.START,
     OBSRecordingAction.STOP,
-    OBSRecordingAction.PAUSE,
-    OBSRecordingAction.UNPAUSE,
 ].map(a => ({
     key: obsRecordingLabel(a),
     value: a,

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -31,6 +31,24 @@ const obsRecordingLabel = (action: OBSRecordingAction): string => {
     }
 };
 
+const pastObsRecordingLabel = (action: OBSRecordingAction): string => {
+    switch (action) {
+        case OBSRecordingAction.TOGGLE:
+            return "toggled";
+        case OBSRecordingAction.START:
+            return "started";
+        case OBSRecordingAction.STOP:
+            return "stopped";
+        case OBSRecordingAction.PAUSE:
+            return "paused";
+        case OBSRecordingAction.UNPAUSE:
+            return "unpaused";
+        default:
+            console.error(`Unknown OBS action: ${action}`);
+            return "";
+    }
+};
+
 const recordActions = [
     OBSRecordingAction.TOGGLE,
     OBSRecordingAction.START,
@@ -65,9 +83,12 @@ const actionToggleRecording: ActionTypeGenerator = (params: ActionToggleRecordin
                 await waitMillis(seconds * 1000);
             }
             await setRecordingState(params.recordAction);
+            if (params.notify) {
+                notify(`${capitalize(pastObsRecordingLabel(params.recordAction))} OBS recording`);
+            }
         } catch (err) {
             console.error(err);
-            notify(`Could not ${obsRecordingLabel(params.recordAction)} OBS recording.`);
+            notify(`Could not ${obsRecordingLabel(params.recordAction)} OBS recording`);
         }
         return ctx;
     };

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -7,8 +7,8 @@ import { Button } from "semantic-ui-react";
 
 import { DelayInput, InlineDropdown, NotifyInput } from "@/components/Misc/InlineInputs";
 import { CustomIcon } from "@/components/Misc/Misc";
-import { connectToOBSAndNotify, getAllSceneItems, setRecordingState, OBSRecordingAction } from "@/lib/obs";
-import { delay as waitMillis, notify, parseSecondsDelayValue, capitalize } from "@/lib/utils";
+import { connectToOBSAndNotify, getAllSceneItems, OBSRecordingAction, setRecordingState } from "@/lib/obs";
+import { capitalize, delay as waitMillis, notify, parseSecondsDelayValue } from "@/lib/utils";
 import { iRootState } from "@/store";
 import { ActionComponent } from "./types";
 

--- a/src/renderer/actions/ActionToggleRecording.tsx
+++ b/src/renderer/actions/ActionToggleRecording.tsx
@@ -88,7 +88,7 @@ const actionToggleRecording: ActionTypeGenerator = (params: ActionToggleRecordin
             }
         } catch (err) {
             console.error(err);
-            notify(`Could not ${obsRecordingLabel(params.recordAction)} OBS recording`);
+            notify(`Could not ${obsRecordingLabel(params.recordAction)} OBS recording. Are you connected to OBS?`);
         }
         return ctx;
     };

--- a/src/renderer/actions/ActionTwitchClip.tsx
+++ b/src/renderer/actions/ActionTwitchClip.tsx
@@ -4,7 +4,7 @@ import { ActionTypeGenerator, Context } from "@vinceau/event-actions";
 import { produce } from "immer";
 import { Icon } from "semantic-ui-react";
 
-import { DelayInput, InlineDropdown, SimpleInput } from "@/components/Misc/InlineInputs";
+import { DelayInput, InlineDropdown, SimpleInput, NotifyInput } from "@/components/Misc/InlineInputs";
 import { delay as waitMillis, notify as sendNotification, parseSecondsDelayValue } from "@/lib/utils";
 import { createTwitchClip } from "common/twitch";
 import { dispatcher, store } from "../store";
@@ -103,22 +103,7 @@ const TwitchClipInput = (props: TwitchClipInputProps) => {
                 {" channel after a "}
                 <DelayInput value={value.delaySeconds} onChange={onDelayChange} placeholder={`${DEFAULT_DELAY_SECONDS}`} />
                 {" second delay and "}
-                <InlineDropdown
-                    value={Boolean(value.notify)}
-                    onChange={onNotifyChange}
-                    options={[
-                        {
-                            key: "notify-me",
-                            value: true,
-                            text: "notify",
-                        },
-                        {
-                            key: "dont-notify-me",
-                            value: false,
-                            text: "don't notify",
-                        },
-                    ]}
-                />
+                <NotifyInput value={value.notify} onChange={onNotifyChange} />
                 {" me about it"}
             </div>
         </div>

--- a/src/renderer/actions/ActionTwitchClip.tsx
+++ b/src/renderer/actions/ActionTwitchClip.tsx
@@ -5,7 +5,7 @@ import { produce } from "immer";
 import { Icon } from "semantic-ui-react";
 
 import { DelayInput, InlineDropdown, SimpleInput } from "@/components/Misc/InlineInputs";
-import { delay as waitMillis, notify as sendNotification } from "@/lib/utils";
+import { delay as waitMillis, notify as sendNotification, parseSecondsDelayValue } from "@/lib/utils";
 import { createTwitchClip } from "common/twitch";
 import { dispatcher, store } from "../store";
 import { ActionComponent } from "./types";
@@ -28,19 +28,11 @@ const defaultParams = (): ActionCreateTwitchClipParams => {
     };
 };
 
-const parseDelayValue = (delay?: string): number => {
-    let seconds = parseInt(delay || DEFAULT_DELAY_SECONDS.toString(), 10);
-    if (isNaN(seconds)) {
-        seconds = DEFAULT_DELAY_SECONDS;
-    }
-    return seconds;
-};
-
 const actionCreateClip: ActionTypeGenerator = (params: ActionCreateTwitchClipParams) => {
     return async (ctx: Context): Promise<Context> => {
         const token = store.getState().twitch.authToken;
         try {
-            const seconds = parseDelayValue(params.delaySeconds);
+            const seconds = parseSecondsDelayValue(DEFAULT_DELAY_SECONDS, params.delaySeconds);
             if (seconds > 0) {
                 await waitMillis(seconds * 1000);
             }

--- a/src/renderer/actions/ActionTwitchClip.tsx
+++ b/src/renderer/actions/ActionTwitchClip.tsx
@@ -4,7 +4,7 @@ import { ActionTypeGenerator, Context } from "@vinceau/event-actions";
 import { produce } from "immer";
 import { Icon } from "semantic-ui-react";
 
-import { DelayInput, InlineDropdown, SimpleInput, NotifyInput } from "@/components/Misc/InlineInputs";
+import { DelayInput, NotifyInput, SimpleInput } from "@/components/Misc/InlineInputs";
 import { delay as waitMillis, notify as sendNotification, parseSecondsDelayValue } from "@/lib/utils";
 import { createTwitchClip } from "common/twitch";
 import { dispatcher, store } from "../store";

--- a/src/renderer/actions/ActionTwitchClip.tsx
+++ b/src/renderer/actions/ActionTwitchClip.tsx
@@ -101,7 +101,7 @@ const TwitchClipInput = (props: TwitchClipInputProps) => {
                     onBlur={onChannelChange}
                 />
                 {" channel after a "}
-                <DelayInput value={value.delaySeconds} onChange={onDelayChange} placeholder="20" />
+                <DelayInput value={value.delaySeconds} onChange={onDelayChange} placeholder={`${DEFAULT_DELAY_SECONDS}`} />
                 {" second delay and "}
                 <InlineDropdown
                     value={Boolean(value.notify)}

--- a/src/renderer/actions/ActionTwitchClip.tsx
+++ b/src/renderer/actions/ActionTwitchClip.tsx
@@ -10,7 +10,7 @@ import { createTwitchClip } from "common/twitch";
 import { dispatcher, store } from "../store";
 import { ActionComponent } from "./types";
 
-const DEFAULT_DELAY_SECONDS = 20;
+const DEFAULT_DELAY_SECONDS = 10;
 
 interface ActionCreateTwitchClipParams {
     delaySeconds?: string;

--- a/src/renderer/actions/ActionTwitchClip.tsx
+++ b/src/renderer/actions/ActionTwitchClip.tsx
@@ -23,7 +23,7 @@ const defaultParams = (): ActionCreateTwitchClipParams => {
     const channel = user ? user.name : "";
     return {
         delaySeconds: DEFAULT_DELAY_SECONDS.toString(),
-        notify: true,
+        notify: false,
         channel,
     };
 };

--- a/src/renderer/actions/index.ts
+++ b/src/renderer/actions/index.ts
@@ -5,11 +5,11 @@ import { ActionChangeScene } from "./ActionChangeScene";
 import { ActionNotify } from "./ActionNotify";
 import { ActionPlaySound } from "./ActionPlaySound";
 import { ActionSaveReplayBuffer } from "./ActionSaveReplayBuffer";
+import { ActionToggleRecording } from "./ActionToggleRecording";
 import { ActionToggleSource } from "./ActionToggleSource";
 import { ActionTwitchClip } from "./ActionTwitchClip";
 import { ActionWriteFile } from "./ActionWriteFile";
 import { ActionComponent } from "./types";
-import { ActionToggleRecording } from "./ActionToggleRecording";
 
 export enum Action {
     CREATE_TWITCH_CLIP = "twitch-clip",

--- a/src/renderer/actions/index.ts
+++ b/src/renderer/actions/index.ts
@@ -9,6 +9,7 @@ import { ActionToggleSource } from "./ActionToggleSource";
 import { ActionTwitchClip } from "./ActionTwitchClip";
 import { ActionWriteFile } from "./ActionWriteFile";
 import { ActionComponent } from "./types";
+import { ActionToggleRecording } from "./ActionToggleRecording";
 
 export enum Action {
     CREATE_TWITCH_CLIP = "twitch-clip",
@@ -18,6 +19,7 @@ export enum Action {
     TOGGLE_SOURCE = "toggle-source",
     WRITE_FILE = "write-file",
     SAVE_REPLAY_BUFFER = "save-replay-buffer",
+    TOGGLE_RECORDING = "toggle-recording",
 }
 
 export interface EventActionConfig {
@@ -43,6 +45,7 @@ export const actionComponents: { [name: string]: ActionComponent} = {
     [Action.CHANGE_SCENE]: ActionChangeScene,
     [Action.TOGGLE_SOURCE]: ActionToggleSource,
     [Action.SAVE_REPLAY_BUFFER]: ActionSaveReplayBuffer,
+    [Action.TOGGLE_RECORDING]: ActionToggleRecording,
 };
 
 for (const [key, value] of Object.entries(actionComponents)) {

--- a/src/renderer/components/Automator/ActionInputs.tsx
+++ b/src/renderer/components/Automator/ActionInputs.tsx
@@ -56,9 +56,10 @@ const ActionComponentBlock = (props: any) => {
 export const ActionInput = (props: any) => {
     const { value, onChange, onRemove, selectPrefix, disabledActions } = props;
     const onActionChange = (action: string) => {
+        const params = actionComponents[action].defaultParams;
         const newValue = produce(value, (draft: ActionDefinition) => {
             draft.name = action;
-            draft.args = {};
+            draft.args = params ? params() : {};
         });
         onChange(newValue);
     };

--- a/src/renderer/components/Misc/InlineInputs.tsx
+++ b/src/renderer/components/Misc/InlineInputs.tsx
@@ -50,28 +50,28 @@ export const InlineInput = (props: any) => {
 };
 
 export const BufferedInput = (props: any) => {
-    const { value, onChange, ...rest } = props;
-    const [newValue, setNewValue] = React.useState<string>(value || "");
-    const submitValue = () => {
-        onChange(newValue);
-    };
-    const onKeyDown = (event: any) => {
-        if (event.keyCode === 13) {
-            submitValue();
-        }
-    };
-    const newOnChange = (_: any, data: any) => {
-        setNewValue(data.value);
-    };
-    return (
-        <Input
-            value={newValue}
-            onChange={newOnChange}
-            onKeyDown={onKeyDown}
-            onBlur={submitValue}
-            {...rest}
-        />
-    );
+  const { value, onChange, ...rest } = props;
+  const [newValue, setNewValue] = React.useState<string>(value || "");
+  const submitValue = () => {
+    onChange(newValue);
+  };
+  const onKeyDown = (event: any) => {
+    if (event.keyCode === 13) {
+      submitValue();
+    }
+  };
+  const newOnChange = (_: any, data: any) => {
+    setNewValue(data.value);
+  };
+  return (
+    <Input
+      value={newValue}
+      onChange={newOnChange}
+      onKeyDown={onKeyDown}
+      onBlur={submitValue}
+      {...rest}
+    />
+  );
 };
 
 export const SimpleInput = styled.input`
@@ -83,18 +83,44 @@ export const SimpleInput = styled.input`
 `;
 
 export const DelayInput: React.FC<{
-    value?: string;
-    placeholder?: string;
-    onChange: (delay: string) => void;
+  value?: string;
+  placeholder?: string;
+  onChange: (delay: string) => void;
 }> = props => {
-    const [delayAmount, setDelayAmount] = React.useState(props.value || "0");
-    return (
-        <SimpleInput
-            style={{width: "100px"}}
-            value={delayAmount}
-            onBlur={() => props.onChange(delayAmount)}
-            onChange={(e) => setDelayAmount(e.target.value)}
-            placeholder={props.placeholder || "2500"}
-        />
-    );
+  const [delayAmount, setDelayAmount] = React.useState(props.value || "0");
+  return (
+    <SimpleInput
+      style={{ width: "100px" }}
+      value={delayAmount}
+      onBlur={() => props.onChange(delayAmount)}
+      onChange={(e) => setDelayAmount(e.target.value)}
+      placeholder={props.placeholder || "2500"}
+    />
+  );
+};
+
+export const NotifyInput: React.FC<{
+  value?: boolean;
+  onChange: (notify: boolean) => void;
+  options?: any;
+}> = (props) => {
+  const options = props.options ? props.options : [
+    {
+      key: "notify-me",
+      value: true,
+      text: "notify",
+    },
+    {
+      key: "dont-notify-me",
+      value: false,
+      text: "don't notify",
+    },
+  ];
+  return (
+    <InlineDropdown
+      value={Boolean(props.value)}
+      onChange={props.onChange}
+      options={options}
+    />
+  );
 };

--- a/src/renderer/lib/obs.ts
+++ b/src/renderer/lib/obs.ts
@@ -3,6 +3,14 @@ import OBSWebSocket from "obs-websocket-js";
 import { dispatcher, store } from "@/store";
 import { notify } from "./utils";
 
+export enum OBSRecordingAction {
+    TOGGLE = "StartStopRecording",
+    START = "StartRecording",
+    STOP = "StopRecording",
+    PAUSE = "PauseRecording",
+    UNPAUSE = "ResumeRecording",
+}
+
 const obs = new OBSWebSocket();
 
 const setupListeners = () => {
@@ -60,6 +68,10 @@ export const setScene = async (scene: string): Promise<void> => {
 
 export const saveReplayBuffer = async (): Promise<void> => {
     await obs.send("SaveReplayBuffer");
+};
+
+export const setRecordingState = async (rec: OBSRecordingAction): Promise<void> => {
+    await obs.send(rec);
 };
 
 export const setSourceItemVisibility = async (sourceName: string, visible?: boolean): Promise<void> => {

--- a/src/renderer/lib/obs.ts
+++ b/src/renderer/lib/obs.ts
@@ -7,8 +7,8 @@ export enum OBSRecordingAction {
     TOGGLE = "StartStopRecording",
     START = "StartRecording",
     STOP = "StopRecording",
-    PAUSE = "PauseRecording",
-    UNPAUSE = "ResumeRecording",
+    // PAUSE = "PauseRecording",
+    // UNPAUSE = "ResumeRecording",
 }
 
 const obs = new OBSWebSocket();

--- a/src/renderer/lib/obs.ts
+++ b/src/renderer/lib/obs.ts
@@ -47,7 +47,7 @@ export const connectToOBSAndNotify = (): void => {
         notify("Successfully connected to OBS");
     }).catch(err => {
         console.error(err);
-        notify(`OBS connection failed`);
+        notify(`OBS connection failed: ${err.error}`);
     });
 };
 

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -92,3 +92,11 @@ export const openFileOrParentFolder = (fileName: string) => {
         opened = shell.openItem(parentFolder);
     }
 };
+
+export const parseSecondsDelayValue = (defaultSeconds: number, delaySeconds?: string): number => {
+    let seconds = parseInt(delaySeconds || defaultSeconds.toString(), 10);
+    if (isNaN(seconds)) {
+        seconds = defaultSeconds;
+    }
+    return seconds;
+};

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -100,3 +100,7 @@ export const parseSecondsDelayValue = (defaultSeconds: number, delaySeconds?: st
     }
     return seconds;
 };
+
+export const capitalize = (s: string) => {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+};


### PR DESCRIPTION
This PR adds the ability to toggle (start/stop) OBS recording.

Additionally, it also fixes the issue where changing an action does not reset the action params to default, reduces the Twitch clip default timeout to 10 seconds, and also defaults all "notify me" actions to `false`. 