### PR TITLE
auto-record updates

### DIFF
--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -37,6 +37,7 @@ export const openComboInDolphin = (comboFilePath: string): void => {
     dispatcher.tempContainer.setDolphin(dolphin);
     if (store.getState().tempContainer.obsConnected && store.getState().tempContainer.recordReplays) {
         dolphin.stdout?.on('data', dolphinStdoutHandler);
+        dolphin.on('close', () => setRecordingState(OBSRecordingAction.STOP));
     }
 };
 

--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -4,7 +4,7 @@ import { remote } from "electron";
 
 import { delay } from '@/lib/utils';
 import { dispatcher, store } from '@/store';
-import {setRecordingState, OBSRecordingAction} from '@/lib/obs'
+import { setRecordingState, OBSRecordingAction } from '@/lib/obs'
 
 export interface DolphinState {
     currentFrame: number,
@@ -32,6 +32,10 @@ const resetState = () => {
     dolphinState.waitForGAME = false;
 }
 
+export const setRecordingStarted = (value: boolean) => {
+    dolphinState.recordingStarted = value;
+}
+
 export const openComboInDolphin = (comboFilePath: string): void => {
     const appData = remote.app.getPath("appData");
     const dolphinPath = path.join(appData, "Slippi Desktop App", "dolphin", "Dolphin.exe");
@@ -56,7 +60,6 @@ const dolphinStdoutHandler = (line: string) => {
                     if (!dolphinState.recordingStarted) {
                         console.log("Start Recording");
                         setRecordingState(OBSRecordingAction.START)
-                        dolphinState.recordingStarted = true;
                     } else {
                         console.log("Resuming Recording");
                         setRecordingState(OBSRecordingAction.UNPAUSE);
@@ -92,7 +95,6 @@ const dolphinStdoutHandler = (line: string) => {
                 console.log("No games remaining in queue");
                 console.log("Stopping Recording");
                 setRecordingState(OBSRecordingAction.STOP);
-                dolphinState.recordingStarted = false;
                 break;
             case (""):
                 break

--- a/src/renderer/lib/obs.ts
+++ b/src/renderer/lib/obs.ts
@@ -2,6 +2,7 @@ import OBSWebSocket from "obs-websocket-js";
 
 import { dispatcher, store } from "@/store";
 import { notify } from "./utils";
+import { setRecordingStarted } from "./dolphin";
 
 export enum OBSRecordingAction {
     TOGGLE = "StartStopRecording",
@@ -28,6 +29,12 @@ const setupListeners = () => {
 
     obs.on("SceneItemRemoved", () => {
         updateScenes().catch(console.error);
+    });
+    obs.on("RecordingStarted", () => {
+        setRecordingStarted(true);
+    });
+    obs.on("RecordingStopped", () => {
+        setRecordingStarted(false);
     });
 };
 


### PR DESCRIPTION
* stop OBS Recording when dolphin process exits (in case the user decides to close dolphin manually or dolphin just crashes)
* wait a second after playback end frame to pause recording if at the end of the game (when GAME! shows up)
* set recordingStarted based on OBS events
* separate DolphinState into DolphinState and RecordingState