### PR TITLE
Add automatic renaming of OBS recorded files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "obs-websocket-js": "^4.0.0",
     "polished": "^3.4.2",
     "react": "^16.8.3",
+    "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.8.3",
     "react-dropzone": "^10.2.2",
     "react-final-form": "^6.3.3",
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
     "@types/howler": "^2.1.2",
+    "@types/react-beautiful-dnd": "^12.1.2",
     "@types/react-dom": "^16.8.2",
     "@types/react-redux": "^7.1.0",
     "@types/react-router-dom": "^5.1.3",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import path from "path";
 
 import { EOL } from "os";
 import { Writable } from "stream";
@@ -81,3 +82,8 @@ export const shuffle = (a: any[]) => {
     }
     return a;
 };
+
+export const onlyFilename = (filepath: string): string => {
+    const onlyExt = path.extname(filepath);
+    return path.basename(filepath, onlyExt);
+}

--- a/src/renderer/components/ConnectionStatusDisplay.tsx
+++ b/src/renderer/components/ConnectionStatusDisplay.tsx
@@ -10,6 +10,8 @@ import { ScanningDot } from "@/components/ScanningDot";
 
 export const ConnectionStatusDisplay: React.FC<{
     icon?: any;
+    iconHoverText?: string;
+    onIconClick?: () => void;
     headerText: string;
     headerHoverTitle: string;
     onHeaderClick?: () => void;
@@ -28,7 +30,19 @@ export const ConnectionStatusDisplay: React.FC<{
     `;
     return (
         <Outer>
-            {props.icon && <img src={props.icon} style={{ height: "35px", width: "35px" }} />}
+            {props.icon &&
+                <Labelled disabled={!props.iconHoverText} title={props.iconHoverText}>
+                    <img
+                        src={props.icon}
+                        onClick={props.onIconClick}
+                        style={{
+                            height: "35px",
+                            width: "35px",
+                            cursor: props.onIconClick ? "pointer" : "auto",
+                        }}
+                    />
+                </Labelled>
+            }
             <ConnectInfo>
                 <Labelled title={props.headerHoverTitle} onClick={props.onHeaderClick} position="right">
                     <Header sub>

--- a/src/renderer/components/DropPad.tsx
+++ b/src/renderer/components/DropPad.tsx
@@ -5,6 +5,8 @@ import styled from "styled-components";
 import { PlaybackQueue } from "./PlaybackQueue";
 import { PlaybackQueueEmpty } from "./PlaybackQueueEmpty";
 
+import { DragDropContext } from "react-beautiful-dnd";
+
 const Outer = styled.div`
 height: 100%;
 width: 100%;
@@ -25,8 +27,10 @@ left: 0;
 `;
 
 export const DropPad: React.FC<{
+    id: string;
     files: any[];
     onDrop: (files: any) => void;
+    onDragEnd: (result: any) => void;
     onRemove?: (index: number) => void;
 }> = (props) => {
     const accept = ".slp";
@@ -39,7 +43,10 @@ export const DropPad: React.FC<{
             <input {...getInputProps()} />
             {
                 props.files.length > 0 ?
-                    <PlaybackQueue files={props.files} removeFile={props.onRemove} /> :
+                    <DragDropContext onDragEnd={props.onDragEnd}>
+                        <PlaybackQueue id={props.id} files={props.files} removeFile={props.onRemove} />
+                    </DragDropContext>
+                    :
                     <PlaybackQueueEmpty onOpen={open}/>
             }
         </Outer>

--- a/src/renderer/components/PlaybackQueue.tsx
+++ b/src/renderer/components/PlaybackQueue.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { PlaybackQueueItem } from "./recorder/PlaybackQueueItem";
-
-interface FileInfo {
-    path: string;
-}
+import { DolphinEntry } from "@vinceau/slp-realtime";
+import { Droppable } from "react-beautiful-dnd";
 
 export const PlaybackQueue: React.FC<{
-    files: FileInfo[];
+    id: string;
+    files: DolphinEntry[];
     removeFile?: (index: number) => void;
 }> = (props) => {
     const removeFile = (index: number, path: string) => {
@@ -16,10 +15,18 @@ export const PlaybackQueue: React.FC<{
         }
     };
     return (
-        <div>
-            {props.files.map((file, i) => (
-                <PlaybackQueueItem key={`${i}--${file.path}`} path={file.path} onRemove={() => removeFile(i, file.path)}/>
-            ))}
-        </div>
+        <Droppable droppableId={props.id}>
+            {(provided) => (
+                <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                >
+                    {props.files.map((file, i) => (
+                        <PlaybackQueueItem key={JSON.stringify(file)} file={file} index={i} onRemove={() => removeFile(i, file.path)} />
+                    ))}
+                    {provided.placeholder}
+                </div>
+            )}
+        </Droppable>
     );
 };

--- a/src/renderer/components/recorder/PlaybackQueueItem.tsx
+++ b/src/renderer/components/recorder/PlaybackQueueItem.tsx
@@ -5,6 +5,9 @@ import styled from "styled-components";
 import { transparentize } from "polished";
 import { Labelled } from "../Labelled";
 
+import { DolphinEntry } from "@vinceau/slp-realtime";
+import { Draggable } from "react-beautiful-dnd";
+
 const Outer = styled.div`
 display: flex;
 flex-direction: row;
@@ -44,20 +47,30 @@ span {
 `;
 
 export const PlaybackQueueItem: React.FC<{
-    path: string;
+    index: number;
+    file: DolphinEntry;
     onRemove?: () => void;
 }> = props => {
-    const basename = path.basename(props.path);
+    const { index, file, onRemove } = props;
+    const basename = path.basename(file.path);
     return (
-        <Outer>
-            <Details>
-                <Icon size="big" name="file outline" />
-                <DetailsContent>
-                    <h3>{basename}</h3>
-                    <span>{props.path}</span>
-                </DetailsContent>
-            </Details>
-            <Labelled title="Remove"><Icon link size="large" name="close" onClick={props.onRemove} /></Labelled>
-        </Outer>
+        <Draggable draggableId={JSON.stringify(file)} index={index}>
+            {provided => (
+                <Outer
+                    {...provided.draggableProps}
+                    {...provided.dragHandleProps}
+                    ref={provided.innerRef}
+                >
+                    <Details>
+                        <Icon size="big" name="file outline" />
+                        <DetailsContent>
+                            <h3>{basename}</h3>
+                            <span>{file.path}</span>
+                        </DetailsContent>
+                    </Details>
+                    <Labelled title="Remove"><Icon link size="large" name="close" onClick={onRemove} /></Labelled>
+                </Outer>
+            )}
+        </Draggable>
     );
 };

--- a/src/renderer/components/recorder/PlaybackQueueItem.tsx
+++ b/src/renderer/components/recorder/PlaybackQueueItem.tsx
@@ -4,19 +4,44 @@ import { Icon } from "semantic-ui-react";
 import styled from "styled-components";
 import { transparentize } from "polished";
 import { Labelled } from "../Labelled";
+import { ThemeMode, useTheme } from "@/styles";
+import { lighten, darken } from "polished";
 
 import { DolphinEntry } from "@vinceau/slp-realtime";
 import { Draggable } from "react-beautiful-dnd";
 
-const Outer = styled.div`
+const Outer = styled.div<{
+    themeName: string;
+    isDragging: boolean;
+}>`
 display: flex;
 flex-direction: row;
 justify-content: space-between;
 align-items: center;
 padding: 10px;
 border-bottom: solid 1px ${p => transparentize(0.8, p.theme.foreground)};
-&:last-child {
-    border-bottom: none;
+background-color: ${p => {
+    const adjust = p.themeName === ThemeMode.DARK ? lighten : darken;
+    return adjust(0.1, p.theme.background);
+}};
+.remove-icon {
+    cursor: pointer;
+    opacity: 0;
+    transition: all 0.4s ease-in-out;
+    padding: 5px;
+}
+${p => p.isDragging && `
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+    &&&,
+`}
+&:hover {
+    background-color: ${p => {
+        const adjust = p.themeName === ThemeMode.DARK ? lighten : darken;
+        return adjust(0.15, p.theme.background);
+    }};
+    .remove-icon {
+        opacity: 1;
+    }
 }
 `;
 
@@ -51,15 +76,17 @@ export const PlaybackQueueItem: React.FC<{
     file: DolphinEntry;
     onRemove?: () => void;
 }> = props => {
+    const theme = useTheme();
     const { index, file, onRemove } = props;
     const basename = path.basename(file.path);
     return (
         <Draggable draggableId={JSON.stringify(file)} index={index}>
-            {provided => (
-                <Outer
+            {(provided, snapshot) => (
+                <Outer themeName={theme.themeName}
                     {...provided.draggableProps}
                     {...provided.dragHandleProps}
                     ref={provided.innerRef}
+                    isDragging={snapshot.isDragging}
                 >
                     <Details>
                         <Icon size="big" name="file outline" />
@@ -68,7 +95,11 @@ export const PlaybackQueueItem: React.FC<{
                             <span>{file.path}</span>
                         </DetailsContent>
                     </Details>
-                    <Labelled title="Remove"><Icon link size="large" name="close" onClick={onRemove} /></Labelled>
+                    <Labelled title="Remove">
+                        <div className="remove-icon" onClick={onRemove}>
+                            <Icon size="large" name="close" />
+                        </div>
+                    </Labelled>
                 </Outer>
             )}
         </Draggable>

--- a/src/renderer/containers/Automator/StatusBar.tsx
+++ b/src/renderer/containers/Automator/StatusBar.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { useHistory } from "react-router-dom";
 import { ConnectionStatus } from "@vinceau/slp-realtime";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -12,6 +13,8 @@ import { Dispatch, iRootState } from "@/store";
 import slippiLogo from "@/styles/images/slippi.png";
 
 export const StatusBar: React.FC = () => {
+    const history = useHistory();
+
     const { port } = useSelector((state: iRootState) => state.slippi);
     const { currentSlpFolderStream, slippiConnectionStatus } = useSelector((state: iRootState) => state.tempContainer);
     const dispatch = useDispatch<Dispatch>();
@@ -42,6 +45,8 @@ export const StatusBar: React.FC = () => {
         <div>
             <ConnectionStatusDisplay
                 icon={slippiLogo}
+                iconHoverText="Open Slippi settings"
+                onIconClick={() => history.push("/settings/slippi-settings")}
                 headerText={headerText}
                 headerHoverTitle={hoverText}
                 onHeaderClick={handleClick}

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -45,7 +45,10 @@ export const OBSStatusBar: React.FC = () => {
     };
 
     const onRecord = () => {
-        loadQueueIntoDolphin({ record: true, pauseBetweenEntries: !recordSeparateClips });
+        loadQueueIntoDolphin({
+            record: true,
+            recordAsOneFile: !recordSeparateClips,
+        });
     };
 
     const handleClick = () => {

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -10,6 +10,7 @@ import { Button, Icon } from "semantic-ui-react";
 import { RecordButton } from "@/components/recorder/RecordButton";
 import obsLogo from "@/styles/images/obs.png";
 import styled from "styled-components";
+import { Labelled } from "@/components/Labelled";
 
 enum RecordingMethod {
     TOGETHER = "together",
@@ -79,7 +80,10 @@ export const OBSStatusBar: React.FC = () => {
         color = obsRecordingStatus === OBSRecordingStatus.STOPPED ? "#00E461" : "#F30807";
     }
     const obsIsRecording = obsRecordingStatus === OBSRecordingStatus.RECORDING;
-
+    const recordButtonDisabled = !obsIsConnected || obsIsRecording;
+    const recordingButtonTitle = !obsIsConnected ? "Connect to OBS to enable recording" :
+        obsIsRecording ? "Recording in progress" :
+        recordValue === RecordingMethod.SEPARATE ? "Record each item as a separate video" : "Record all items together as a single video";
     return (
         <Outer>
             <ConnectionStatusDisplay
@@ -93,16 +97,18 @@ export const OBSStatusBar: React.FC = () => {
                 {innerText}
             </ConnectionStatusDisplay>
             <div>
-                <RecordButton
-                    onClick={onRecord}
-                    disabled={!obsIsConnected || obsIsRecording}
-                    onChange={onRecordChange}
-                    value={recordValue}
-                    options={recordingOptions}
-                >
-                    <Icon name="circle" />{recordButtonText}
-                </RecordButton>
-                <Button onClick={onPlay} style={{marginLeft: "0.25em"}} disabled={dolphinQueue.length === 0}><Icon name="play" />Play</Button>
+                <Labelled title={recordingButtonTitle} disabled={!recordButtonDisabled}>
+                    <RecordButton
+                        onClick={onRecord}
+                        disabled={recordButtonDisabled}
+                        onChange={onRecordChange}
+                        value={recordValue}
+                        options={recordingOptions}
+                    >
+                        <Icon name="circle" />{recordButtonText}
+                    </RecordButton>
+                </Labelled>
+                <Button onClick={onPlay} style={{ marginLeft: "0.25em" }} disabled={dolphinQueue.length === 0}><Icon name="play" />Play</Button>
             </div>
         </Outer>
     );

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { useHistory } from "react-router-dom";
 import { ConnectionStatusDisplay } from "@/components/ConnectionStatusDisplay";
 import { loadQueueIntoDolphin } from "@/lib/dolphin";
 import { OBSConnectionStatus, OBSRecordingStatus } from "@/lib/obs";
@@ -38,6 +39,7 @@ align-items: center;
 `;
 
 export const OBSStatusBar: React.FC = () => {
+    const history = useHistory();
     const { recordSeparateClips } = useSelector((state: iRootState) => state.filesystem);
     const { obsConnectionStatus, obsRecordingStatus, dolphinQueue, dolphinPlaybackFile } = useSelector((state: iRootState) => state.tempContainer);
     const dispatch = useDispatch<Dispatch>();
@@ -97,6 +99,8 @@ export const OBSStatusBar: React.FC = () => {
         <Outer>
             <ConnectionStatusDisplay
                 icon={obsLogo}
+                iconHoverText="Open OBS settings"
+                onIconClick={() => history.push("/settings/obs-settings")}
                 headerText={headerText}
                 headerHoverTitle={hoverText}
                 onHeaderClick={handleClick}

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -17,10 +17,18 @@ enum RecordingMethod {
     SEPARATE = "separate",
 }
 
-const recordingOptions = [
-    { icon: "file video outline", text: "Together as one video", value: RecordingMethod.TOGETHER },
-    { icon: "film", text: "Seperate clips", value: RecordingMethod.SEPARATE },
-];
+const recordingOptions = {
+    [RecordingMethod.TOGETHER]: {
+        title: "Record all items together as a single video",
+        icon: "file video outline",
+        text: "Together as one video",
+    },
+    [RecordingMethod.SEPARATE]: {
+        title: "Record each item as a separate video",
+        icon: "film",
+        text: "Seperate clips",
+    },
+};
 
 const Outer = styled.div`
 display: flex;
@@ -84,6 +92,7 @@ export const OBSStatusBar: React.FC = () => {
     const recordingButtonTitle = !obsIsConnected ? "Connect to OBS to enable recording" :
         obsIsRecording ? "Recording in progress" :
         recordValue === RecordingMethod.SEPARATE ? "Record each item as a separate video" : "Record all items together as a single video";
+    const options = Object.entries(recordingOptions).map(([key, val]) => ({...val, value: key}));
     return (
         <Outer>
             <ConnectionStatusDisplay
@@ -103,7 +112,7 @@ export const OBSStatusBar: React.FC = () => {
                         disabled={recordButtonDisabled}
                         onChange={onRecordChange}
                         value={recordValue}
-                        options={recordingOptions}
+                        options={options}
                     >
                         <Icon name="circle" />{recordButtonText}
                     </RecordButton>

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -75,6 +75,7 @@ export const OBSStatusBar: React.FC = () => {
     if (obsIsConnected) {
         color = obsRecordingStatus === OBSRecordingStatus.STOPPED ? "#00E461" : "#F30807";
     }
+    const obsIsRecording = obsRecordingStatus === OBSRecordingStatus.RECORDING;
 
     return (
         <Outer>
@@ -83,7 +84,7 @@ export const OBSStatusBar: React.FC = () => {
                 headerText={headerText}
                 headerHoverTitle={hoverText}
                 onHeaderClick={handleClick}
-                shouldPulse={obsRecordingStatus === OBSRecordingStatus.RECORDING}
+                shouldPulse={obsIsRecording}
                 color={color}
             >
                 {innerText}
@@ -91,7 +92,7 @@ export const OBSStatusBar: React.FC = () => {
             <div>
                 <RecordButton
                     onClick={onRecord}
-                    disabled={!obsIsConnected}
+                    disabled={!obsIsConnected || obsIsRecording}
                     onChange={onRecordChange}
                     value={recordValue}
                     options={recordingOptions}

--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -21,6 +21,7 @@ import { store } from "@/store";
 import { DolphinLauncher, DolphinPlaybackPayload, DolphinPlaybackStatus, DolphinQueueFormat, generateDolphinQueuePayload } from "@vinceau/slp-realtime";
 import { BehaviorSubject, from } from "rxjs";
 import { concatMap, filter } from "rxjs/operators";
+import { onlyFilename } from "common/utils";
 
 const DELAY_AMOUNT_MS = 1000;
 
@@ -114,9 +115,9 @@ export class DolphinRecorder extends DolphinLauncher {
 
         if (this.recordAsOneFile) {
             // We're going to save the file as the JSON basename
-            return obsConnection.setFilenameFormat(this.currentJSONFileSource.value);
+            return obsConnection.setFilenameFormat(onlyFilename(this.currentJSONFileSource.value));
         }
-        return obsConnection.setFilenameFormat(filename);
+        return obsConnection.setFilenameFormat(onlyFilename(filename));
     }
 
     private async _startRecording(): Promise<void> {

--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -31,6 +31,7 @@ const DELAY_AMOUNT_MS = 1000;
 const defaultDolphinRecorderOptions = {
     record: false,
     recordAsOneFile: true,
+    outputFilename: "",
 };
 
 export type DolphinRecorderOptions = typeof defaultDolphinRecorderOptions;
@@ -113,11 +114,15 @@ export class DolphinRecorder extends DolphinLauncher {
         // First store the current filename format so we can restore it later
         this.userFilenameFormat = await obsConnection.getFilenameFormat();
 
-        if (this.recordOptions.recordAsOneFile) {
-            // We're going to save the file as the JSON basename
-            return obsConnection.setFilenameFormat(onlyFilename(this.currentJSONFileSource.value));
+        // If we're recording as separate files use the SLP filename
+        if (!this.recordOptions.recordAsOneFile) {
+            return obsConnection.setFilenameFormat(onlyFilename(filename));
         }
-        return obsConnection.setFilenameFormat(onlyFilename(filename));
+
+        // If we're provided an output filename use that
+        if (this.recordOptions.outputFilename) {
+            return obsConnection.setFilenameFormat(this.recordOptions.outputFilename);
+        }
     }
 
     private async _startRecording(): Promise<void> {

--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -70,9 +70,11 @@ export class DolphinRecorder extends DolphinLauncher {
         ).subscribe();
     }
 
-    public recordJSON(comboFilePath: string, options?: Partial<DolphinRecorderOptions>) {
+    public async recordJSON(comboFilePath: string, options?: Partial<DolphinRecorderOptions>): Promise<void> {
         this.recordOptions = Object.assign({}, defaultDolphinRecorderOptions, options);
         if (this.recordOptions.record) {
+            // First store the current filename format so we can restore it later
+            this.userFilenameFormat = await obsConnection.getFilenameFormat();
         }
         this.currentJSONFileSource.next(comboFilePath);
         super.loadJSON(comboFilePath);
@@ -109,9 +111,6 @@ export class DolphinRecorder extends DolphinLauncher {
             return;
         }
 
-        // First store the current filename format so we can restore it later
-        this.userFilenameFormat = await obsConnection.getFilenameFormat();
-
         // Store the new filename here, defaulting to the original filename format
         let newFilename = this.userFilenameFormat;
         if (!this.recordOptions.recordAsOneFile) {
@@ -127,7 +126,8 @@ export class DolphinRecorder extends DolphinLauncher {
         }
 
         // Actually set the filename
-        return obsConnection.setFilenameFormat(newFilename);
+        await obsConnection.setFilenameFormat(newFilename);
+        return;
     }
 
     private async _startRecording(): Promise<void> {
@@ -163,7 +163,7 @@ export const dolphinPlayer = new DolphinRecorder(getDolphinPath(), {
 });
 
 export const openComboInDolphin = (filePath: string, options?: Partial<DolphinRecorderOptions>) => {
-    dolphinPlayer.recordJSON(filePath, options);
+    dolphinPlayer.recordJSON(filePath, options).catch(console.error);
 };
 
 export const loadSlpFilesInDolphin = async (filenames: string[], options?: Partial<DolphinRecorderOptions>): Promise<void> => {

--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -32,6 +32,7 @@ const defaultDolphinRecorderOptions = {
     record: false,
     recordAsOneFile: true,
     outputFilename: "",
+    outputFolder: "ProjectClippi",
 };
 
 export type DolphinRecorderOptions = typeof defaultDolphinRecorderOptions;
@@ -114,15 +115,22 @@ export class DolphinRecorder extends DolphinLauncher {
         // First store the current filename format so we can restore it later
         this.userFilenameFormat = await obsConnection.getFilenameFormat();
 
-        // If we're recording as separate files use the SLP filename
+        // Store the new filename here, defaulting to the original filename format
+        let newFilename = this.userFilenameFormat;
         if (!this.recordOptions.recordAsOneFile) {
-            return obsConnection.setFilenameFormat(onlyFilename(filename));
+            // If we're recording as separate files use the SLP filename
+            newFilename = onlyFilename(filename);
+        } else if (this.recordOptions.outputFilename) {
+            // If we're provided an output filename use that
+            newFilename = this.recordOptions.outputFilename;
         }
 
-        // If we're provided an output filename use that
-        if (this.recordOptions.outputFilename) {
-            return obsConnection.setFilenameFormat(this.recordOptions.outputFilename);
+        if (this.recordOptions.outputFolder) {
+            newFilename = path.join(this.recordOptions.outputFolder, newFilename);
         }
+
+        // Actually set the filename
+        return obsConnection.setFilenameFormat(newFilename);
     }
 
     private async _startRecording(): Promise<void> {

--- a/src/renderer/lib/dolphin.ts
+++ b/src/renderer/lib/dolphin.ts
@@ -44,8 +44,6 @@ const getDolphinPath = (): string => {
 
 export class DolphinRecorder extends DolphinLauncher {
     private recordOptions: DolphinRecorderOptions;
-    private startAction = OBSRecordingAction.START;
-    private endAction = OBSRecordingAction.STOP;
 
     // We use this to track the original OBS filename format so we can restore it later
     private userFilenameFormat: string = "";
@@ -75,8 +73,6 @@ export class DolphinRecorder extends DolphinLauncher {
     public recordJSON(comboFilePath: string, options?: Partial<DolphinRecorderOptions>) {
         this.recordOptions = Object.assign({}, defaultDolphinRecorderOptions, options);
         if (this.recordOptions.record) {
-            this.startAction = this.recordOptions.recordAsOneFile ? OBSRecordingAction.UNPAUSE : OBSRecordingAction.START;
-            this.endAction = this.recordOptions.recordAsOneFile ? OBSRecordingAction.PAUSE : OBSRecordingAction.STOP;
         }
         this.currentJSONFileSource.next(comboFilePath);
         super.loadJSON(comboFilePath);
@@ -97,7 +93,8 @@ export class DolphinRecorder extends DolphinLauncher {
                 if (payload.data && payload.data.gameEnded) {
                     await delay(DELAY_AMOUNT_MS);
                 }
-                await obsConnection.setRecordingState(this.endAction);
+                const endAction = this.recordOptions.recordAsOneFile ? OBSRecordingAction.PAUSE : OBSRecordingAction.STOP;
+                await obsConnection.setRecordingState(endAction);
                 break;
             case DolphinPlaybackStatus.QUEUE_EMPTY:
                 // Stop recording and quit Dolphin
@@ -134,7 +131,8 @@ export class DolphinRecorder extends DolphinLauncher {
     }
 
     private async _startRecording(): Promise<void> {
-        const action = obsConnection.isRecording() ? this.startAction : OBSRecordingAction.START;
+        const startAction = this.recordOptions.recordAsOneFile ? OBSRecordingAction.UNPAUSE : OBSRecordingAction.START;
+        const action = obsConnection.isRecording() ? startAction : OBSRecordingAction.START;
         await obsConnection.setRecordingState(action);
     }
 

--- a/src/renderer/lib/obs.ts
+++ b/src/renderer/lib/obs.ts
@@ -75,10 +75,12 @@ class OBSConnection {
         this.connectionSource$.next(OBSConnectionStatus.DISCONNECTED);
     }
 
-    public async setFilenameFormat(format: string): Promise<void> {
+    public async setFilenameFormat(format: string): Promise<boolean> {
         await this.socket.send("SetFilenameFormatting", {
             "filename-formatting": format,
         });
+        const confirmFormat = await this.getFilenameFormat();
+        return confirmFormat === format;
     }
 
     public async getFilenameFormat(): Promise<string> {

--- a/src/renderer/lib/obs.ts
+++ b/src/renderer/lib/obs.ts
@@ -68,6 +68,17 @@ class OBSConnection {
         this.connectionSource$.next(OBSConnectionStatus.DISCONNECTED);
     }
 
+    public async setFilenameFormat(format: string): Promise<void> {
+        await this.socket.send("SetFilenameFormatting", {
+            "filename-formatting": format,
+        });
+    }
+
+    public async getFilenameFormat(): Promise<string> {
+        const response = await this.socket.send("GetFilenameFormatting");
+        return response["filename-formatting"];
+    }
+
     public async setScene(scene: string) {
         await this.socket.send("SetCurrentScene", {
             "scene-name": scene,

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as url from "url";
 
-import { DolphinPlayerOptions, openComboInDolphin } from "@/lib/dolphin";
+import { DolphinRecorderOptions, openComboInDolphin } from "@/lib/dolphin";
 import { Message } from "common/types";
 import { remote, shell } from "electron";
 import fs from "fs-extra";
@@ -70,7 +70,7 @@ export const getStatic = (val: string): string => {
     return path.resolve(path.join(imagePath, val));
 };
 
-export const loadFileInDolphin = async (options?: Partial<DolphinPlayerOptions>): Promise<void> => {
+export const loadFileInDolphin = async (options?: Partial<DolphinRecorderOptions>): Promise<void> => {
     const p = await getFilePath({
         filters: [{ name: "JSON files", extensions: ["json"] }],
     });

--- a/src/renderer/store/models/tempContainer.ts
+++ b/src/renderer/store/models/tempContainer.ts
@@ -169,7 +169,7 @@ export const tempContainer = createModel({
         async addFileToDolphinQueue() {
             const p = await getFilePath({
                 filters: [{ name: "SLP files", extensions: ["slp"] }],
-                properties: ["openFile", "openDirectory", "multiSelections"],
+                properties: ["openFile", "multiSelections"],
             }, false);
             if (p && p.length > 0) {
                 dispatch.tempContainer.appendDolphinQueue(

--- a/src/renderer/store/models/tempContainer.ts
+++ b/src/renderer/store/models/tempContainer.ts
@@ -118,6 +118,12 @@ export const tempContainer = createModel({
                 draft.dolphinQueue.splice(index, 1);
             });
         },
+        moveDolphinQueueEntry: (state: TempContainerState, payload: { startIndex: number, endIndex: number }): TempContainerState => {
+            const { startIndex, endIndex } = payload;
+            return produce(state, draft => {
+                draft.dolphinQueue.splice(endIndex, 0, draft.dolphinQueue.splice(startIndex, 1)[0]);
+            });
+        },
         appendDolphinQueue: (state: TempContainerState, payload: DolphinEntry[]): TempContainerState => {
             // Disallow duplicate paths
             const existingPaths = state.dolphinQueue.map(f => f.path);

--- a/src/renderer/styles/global.ts
+++ b/src/renderer/styles/global.ts
@@ -31,6 +31,19 @@ export const GlobalStyle = createGlobalStyle<{
       color: ${({theme}) => theme.foreground} !important;
     }
 
+    .ui.card {
+      border: solid 1px ${({theme}) => theme.background3} !important;
+      box-shadow: none;
+      background: ${({theme}) => lighten(0.05, theme.background)};
+      .meta,
+      .header {
+        color: ${({theme}) => theme.foreground};
+      }
+      .extra {
+        border-color: ${({theme}) => theme.background3} !important;
+      }
+    }
+
     .ui.placeholder.segment,
     .ui.table thead th,
     .ui.table {

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -93,6 +93,22 @@ export const RecorderView: React.FC = () => {
     const onSaveHandler = () => {
         saveQueueToFile().catch(console.error);
     };
+    const onDragEnd = (result: any) => {
+        const { destination, source } = result;
+        if (!destination) {
+            return;
+        }
+        if (
+            destination.droppableId === source.droppableId &&
+            destination.index === source.index
+        ) {
+            return;
+        }
+        dispatch.tempContainer.moveDolphinQueueEntry({
+            startIndex: source.index,
+            endIndex: destination.index,
+        });
+    }
     const validQueue = dolphinQueue.length > 0;
     return (
         <Outer>
@@ -115,6 +131,8 @@ export const RecorderView: React.FC = () => {
                 </Toolbar>
                 <MainBody themeName={theme.themeName}>
                     <DropPad
+                        id="recorder-drop-pad"
+                        onDragEnd={onDragEnd}
                         onDrop={(files) => droppedFilesHandler(files)} files={dolphinQueue}
                         onRemove={onRemove}
                     />

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -107,11 +107,11 @@ export const RecorderView: React.FC = () => {
                             <Icon name="save" /> Save JSON
                         </Button>
                     </div>
-                    <div>
+                    {validQueue && <div>
                         <Labelled title="Add file"><Button onClick={addFileHandler} icon="plus" /></Labelled>
-                        <Labelled title="Shuffle queue"><Button onClick={shuffleQueueHandler} disabled={!validQueue} icon="shuffle" /></Labelled>
-                        <Labelled title="Clear queue"><Button onClick={clearQueueHandler} disabled={!validQueue} icon="trash" /></Labelled>
-                    </div>
+                        <Labelled title="Shuffle queue"><Button onClick={shuffleQueueHandler} icon="shuffle" /></Labelled>
+                        <Labelled title="Clear queue"><Button onClick={clearQueueHandler} icon="trash" /></Labelled>
+                    </div>}
                 </Toolbar>
                 <MainBody themeName={theme.themeName}>
                     <DropPad

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.4":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -946,6 +953,13 @@
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.0.tgz#2a5fa918786d07d3725726f7f650527e1cfeaffd"
   integrity sha512-c4zji5CjWv1tJxIZkz1oUtGcdOlsH3aza28Nqmm+uNDWBRHoMsjooBEN4czZp1V3iXPihE/VRUOBqg+4Xq0W4g==
+
+"@types/react-beautiful-dnd@^12.1.2":
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-12.1.2.tgz#dfd1bdb072e92c1363e5f7a4c1842eaf95f77b21"
+  integrity sha512-h+0mA4cHmzL4BhyCniB6ZSSZhfO9LpXXbnhdAfa2k7klS03woiOT+Dh5AchY6eoQXk3vQVtqn40YY3u+MwFs8A==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-dom@*", "@types/react-dom@^16.8.2":
   version "16.9.4"
@@ -2671,6 +2685,13 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
+
+css-box-model@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
+  integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -5507,7 +5528,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.0:
+memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -7015,6 +7036,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+raf-schd@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
+  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
+
 ramda@^0.26:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
@@ -7067,6 +7093,19 @@ rc@^1.2.1, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-beautiful-dnd@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz#f70cc8ff82b84bc718f8af157c9f95757a6c3b40"
+  integrity sha512-87It8sN0ineoC3nBW0SbQuTFXM6bUqM62uJGY4BtTf0yzPl8/3+bHMWkgIe0Z6m8e+gJgjWxefGRVfpE3VcdEg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.1.1"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-dom@^16.8.3:
   version "16.12.0"
@@ -7169,6 +7208,17 @@ react-redux@^7.1.0:
     "@babel/runtime" "^7.5.5"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
+
+react-redux@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
@@ -7398,6 +7448,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"
@@ -8606,6 +8661,11 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
 
+tiny-invariant@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
 tiny-warning@^1.0.0, tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
@@ -9104,6 +9164,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This PR ensures that the files recorded with Project Clippi are renamed to match the original SLP files if recorded separately. It also allows setting custom options such as output filenames and output folders. It records all files in a "ProjectClippi" folder inside their default output directory.

Restoration of the original OBS filename format happens at the end of the dolphin queue, or when the dolphin instance is terminated. If Clippi is closed manually the OBS filename format will not restore!!

Additionally this PR also adds drag and drop support for the playback queue using `react-beautiful-dnd`.