### PR TITLE
Make styles responsive using rem units

### DIFF
--- a/src/common/fileProcessor.ts
+++ b/src/common/fileProcessor.ts
@@ -46,7 +46,6 @@ export interface FileProcessorOptions {
     includeSubFolders?: boolean;
     outputFile?: string;
     renameTemplate?: string;
-    openCombosWhenDone?: boolean;
     config: Partial<ButtonInputOptions> | ComboOptions;
 }
 

--- a/src/common/fileProcessor.ts
+++ b/src/common/fileProcessor.ts
@@ -37,7 +37,6 @@ export interface ButtonInputOptions {
 export interface ComboOptions {
     findComboCriteria: Partial<ComboFilterSettings>;
     deleteZeroComboFiles?: boolean;
-    openCombosWhenDone?: boolean;
 }
 
 export interface FileProcessorOptions {
@@ -47,6 +46,7 @@ export interface FileProcessorOptions {
     includeSubFolders?: boolean;
     outputFile?: string;
     renameTemplate?: string;
+    openCombosWhenDone?: boolean;
     config: Partial<ButtonInputOptions> | ComboOptions;
 }
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -56,18 +56,34 @@ export const getMenuTemplate = (app: App, platform: string): Electron.MenuItemCo
     };
     menuItems.push(edit);
 
+    const view: Electron.MenuItemConstructorOptions = {
+        label: "View",
+        submenu: [
+            { role: "reload" },
+            { role: "forcereload" },
+            { role: "toggledevtools" },
+            { type: "separator" },
+            { role: "resetzoom" },
+            { role: "zoomin", accelerator: "CommandOrControl+=" },
+            { role: "zoomout" },
+            { type: "separator" },
+            { role: "togglefullscreen" }
+        ]
+    };
+    menuItems.push(view);
+
     if (platform === "darwin") {
         menuItems.push(
-        {
-            type: "separator"
-        },
-        {
-            label: "Quit",
-            click: () => {
-                app.quit();
+            {
+                type: "separator"
+            },
+            {
+                label: "Quit",
+                click: () => {
+                    app.quit();
+                }
             }
-        }
-    );
+        );
     }
     return menuItems;
 };

--- a/src/renderer/components/ContextOptions.tsx
+++ b/src/renderer/components/ContextOptions.tsx
@@ -30,8 +30,9 @@ export const ContextOptions: React.FC<{
                 arrow={true}
                 duration={200}
                 position="top"
+                size="big"
             >
-                <Label as="a" onClick={() => clickHandler(d.contextName)} style={{margin: "2px"}}>{d.contextName}</Label>
+                <Label as="a" onClick={() => clickHandler(d.contextName)} style={{margin: "2px", fontSize: "1.1rem"}}>{d.contextName}</Label>
             </TippyLabel>
         ))}
         </div>

--- a/src/renderer/components/Form.tsx
+++ b/src/renderer/components/Form.tsx
@@ -9,7 +9,7 @@ max-width: 65rem;
 
 export const PageHeader = styled.h1`
 font-variant: all-small-caps;
-margin-bottom: 1rem;
+margin-bottom: 2rem;
 `;
 
 export const Label = styled.div`

--- a/src/renderer/components/Form.tsx
+++ b/src/renderer/components/Form.tsx
@@ -4,44 +4,44 @@ import { Checkbox } from "semantic-ui-react";
 import styled from "styled-components";
 
 export const FormContainer = styled.div`
-max-width: 650px;
+max-width: 65rem;
 `;
 
 export const PageHeader = styled.h1`
 font-variant: all-small-caps;
-margin-bottom: 10px;
+margin-bottom: 1rem;
 `;
 
 export const Label = styled.div`
 &&& {
 font-weight: 500;
-font-size: 14px;
-margin-bottom: 10px;
+font-size: 1.4rem;
+margin-bottom: 1rem;
 }
 `;
 
 export const Text = styled.p<{
     margin?: string;
 }>`
-font-size: 12px;
+font-size: 1.2rem;
 opacity: 0.8;
 ${p => p.margin !== "none" && `
-margin-top: 10px;
+margin-top: 1rem;
 `}
 `;
 
 export const Field = styled.div<{
     border?: string;
 }>`
-padding-top: 20px;
-padding-bottom: 20px;
+padding-top: 2rem;
+padding-bottom: 2rem;
 
 ${p => (p.border === "top" || p.border === "both") && `
-border-top: solid 1px ${p.theme.foreground3};
+border-top: solid 0.1rem ${p.theme.foreground3};
 `}
 
 ${p => (p.border === "bottom" || p.border === "both") && `
-border-bottom: solid 1px ${p.theme.foreground3};
+border-bottom: solid 0.1rem ${p.theme.foreground3};
 `}
 
 `;

--- a/src/renderer/components/Form.tsx
+++ b/src/renderer/components/Form.tsx
@@ -32,9 +32,15 @@ margin-top: 1rem;
 
 export const Field = styled.div<{
     border?: string;
+    padding?: string;
 }>`
+${p => (p.padding === "top" || p.padding === "both") && `
 padding-top: 2rem;
+`}
+
+${p => (p.padding === "bottom" || p.padding === "both") && `
 padding-bottom: 2rem;
+`}
 
 ${p => (p.border === "top" || p.border === "both") && `
 border-top: solid 0.1rem ${p.theme.foreground3};
@@ -43,8 +49,10 @@ border-top: solid 0.1rem ${p.theme.foreground3};
 ${p => (p.border === "bottom" || p.border === "both") && `
 border-bottom: solid 0.1rem ${p.theme.foreground3};
 `}
-
 `;
+Field.defaultProps = {
+    padding: "both",
+}
 
 const ToggleOuter = styled.div`
 display: flex;

--- a/src/renderer/components/InlineInputs.tsx
+++ b/src/renderer/components/InlineInputs.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { Dropdown, Input } from "semantic-ui-react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 const generateOptions = (events: string[], mapOptionToLabel?: (opt: string) => string, selectedValue?: string, disabledEvents?: string[]): Array<{ key: string; text: string; value: string }> => {
   const disabled = disabledEvents || [];

--- a/src/renderer/components/InlineInputs.tsx
+++ b/src/renderer/components/InlineInputs.tsx
@@ -14,16 +14,7 @@ const generateOptions = (events: string[], mapOptionToLabel?: (opt: string) => s
 };
 
 export const InlineDropdown = (props: any) => {
-  const { value, customOptions, options, onChange, mapOptionToLabel, fontSize, prefix, disabledOptions, ...rest } = props;
-  const fontSizeCSS = (size: number) => css`
-    &&&,
-    * {
-      font-size: ${size}px;
-    }
-  `;
-  const Outer = styled.span`
-    ${fontSize ? fontSizeCSS(fontSize) : ""}
-  `;
+  const { value, customOptions, options, onChange, mapOptionToLabel, prefix, disabledOptions, ...rest } = props;
   let newOptions;
   if (customOptions && !options) {
     newOptions = generateOptions(customOptions, mapOptionToLabel, value, disabledOptions);
@@ -31,7 +22,7 @@ export const InlineDropdown = (props: any) => {
     newOptions = options;
   }
   return (
-    <Outer>
+    <span>
       {props.prefix ? `${props.prefix} ` : ""}
       <Dropdown
         scrolling={true}
@@ -41,7 +32,7 @@ export const InlineDropdown = (props: any) => {
         value={value}
         onChange={(_: any, { value }) => onChange(value)}
       />
-    </Outer>
+    </span>
   );
 };
 

--- a/src/renderer/components/Labelled.tsx
+++ b/src/renderer/components/Labelled.tsx
@@ -25,7 +25,7 @@ export const Labelled = (props: any) => {
     };
     return (
         <span style={onClick ? pointerStyle : undefined} onClick={onClick}>
-            <TippyLabel arrow={true} duration={200} position="bottom" {...rest}>
+            <TippyLabel size="big" arrow={true} duration={200} position="bottom" {...rest}>
                 {children}
             </TippyLabel>
         </span>

--- a/src/renderer/components/ProcessSection.tsx
+++ b/src/renderer/components/ProcessSection.tsx
@@ -14,7 +14,7 @@ padding: 20px 0;
 border-top: solid 1px ${({ theme }) => theme.foreground3};
 `;
 
-const SectionLabel = styled.h3`
+const SectionLabel = styled.h2`
 cursor: pointer;
 margin-bottom: 0;
 `;

--- a/src/renderer/components/combos/CharacterSelect.tsx
+++ b/src/renderer/components/combos/CharacterSelect.tsx
@@ -64,10 +64,11 @@ export const CharacterSelect = (props: any) => {
   const newOnChange = (v: any) => onChange(parseValue(v));
   const selectOptions = options ? options : sortedCharacterIDs;
   const mainTheme = useTheme();
+  const minHeight = "3.8rem";
   const customStyles: any = {
       dropdownIndicator: (base: any) => ({
         ...base,
-        padding: "0 8px",
+        padding: "0 0.8rem",
       }),
       multiValue: (base: any) => ({
         ...base,
@@ -79,7 +80,7 @@ export const CharacterSelect = (props: any) => {
       }),
       control: (base: any) => ({
         ...base,
-        minHeight: "35px",
+        minHeight,
       }),
   };
   if (mainTheme.themeName === ThemeMode.DARK) {
@@ -90,14 +91,14 @@ export const CharacterSelect = (props: any) => {
       });
       customStyles.dropdownIndicator = (base: any) => ({
         ...base,
-        padding: "0 8px",
+        padding: "0 0.8rem",
         color: mainTheme.theme.background,
       });
       customStyles.control = (base: any) => ({
         ...base,
         backgroundColor: mainTheme.theme.foreground,
         color: mainTheme.theme.background,
-        minHeight: "35px",
+        minHeight,
       });
   }
 

--- a/src/renderer/components/combos/PerCharPercent.tsx
+++ b/src/renderer/components/combos/PerCharPercent.tsx
@@ -6,27 +6,13 @@ import { FieldArray } from "react-final-form-arrays";
 import { Button, Icon } from "semantic-ui-react";
 
 import { CharPercentOption } from "@/lib/profile";
-import { device } from "@/styles/device";
 import { SemanticInput } from "../../containers/Settings/ComboForm/FormAdapters";
 import { CharacterSelectAdapter } from "./CharacterSelect";
 
 const CharacterSelectContainer = styled.div`
-display: flex;
-flex-direction: column;
-align-items: center;
-padding: 5px 0;
-& > div {
-    padding: 2px;
-    flex-basis: 100%;
-    width: 100%;
-}
-@media ${device.tablet} {
-    flex-direction: row;
-    & > div {
-        flex-basis: 50%;
-        width: 50%;
-    }
-}
+display: grid;
+grid-gap: 1rem;
+grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr) );
 `;
 
 export const PerCharPercent: React.FC<{ name: string; values: any; push: any; pop: any }> = props => {

--- a/src/renderer/components/combos/PercentageSlider.tsx
+++ b/src/renderer/components/combos/PercentageSlider.tsx
@@ -1,5 +1,12 @@
 import React from "react";
+import styled from "styled-components";
 import { Field } from "react-final-form";
+
+const Outer = styled.div`
+display: grid;
+grid-gap: 2rem;
+grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr) );
+`;
 
 export const PercentageSlider: React.FC<{
     name: string;
@@ -9,7 +16,15 @@ export const PercentageSlider: React.FC<{
     const min = props.min || "0";
     const max = props.max || "100";
     return (
-        <div>
+        <Outer>
+            <Field
+                parse={(v) => parseFloat(v)}
+                name={props.name}
+                min={min}
+                max={max}
+                component="input"
+                type="text"
+            />
             <Field
                 parse={(v) => parseFloat(v)}
                 name={props.name}
@@ -19,14 +34,6 @@ export const PercentageSlider: React.FC<{
                 max={max}
                 step={`${parseInt(max, 10) / 100}`}
             />
-            <Field
-                parse={(v) => parseFloat(v)}
-                name={props.name}
-                min={min}
-                max={max}
-                component="input"
-                type="text"
-            />
-        </div>
+        </Outer>
     );
 };

--- a/src/renderer/components/combos/ProfileSelection.tsx
+++ b/src/renderer/components/combos/ProfileSelection.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 
 import styled from "styled-components";
 
-import { Divider, Dropdown } from "semantic-ui-react";
+import { Dropdown } from "semantic-ui-react";
+import { Text, Label, Field } from "../Form";
+import { lighten } from "polished";
 
 const generateOptions = (opts: string[]) => {
     return opts.map(o => ({
@@ -12,20 +14,22 @@ const generateOptions = (opts: string[]) => {
     }));
 };
 
+const Outer = styled.div`
+padding: 0 2rem;
+border-radius: 0.5rem;
+background-color: ${({theme}) => lighten(0.05, theme.background)};
+`;
+
 export const ProfileSelector = (props: any) => {
     const { initialOptions, value, onChange, ...rest } = props;
     const options = generateOptions(initialOptions);
     const handleChange = (_: any, { value }: any) => onChange(value);
-    const Text = styled.span`
-    font-weight: bold;
-    margin-right: 5px;
-    `;
     return (
-        <div>
-            <Divider />
-            <Text>Current Profile</Text>
+    <Outer>
+        <Field>
+           <Label>Current Profile</Label>
             <Dropdown
-                {...rest}
+                style={{ width: "100%" }}
                 options={options}
                 placeholder="Select a profile"
                 search
@@ -34,8 +38,13 @@ export const ProfileSelector = (props: any) => {
                 value={value}
                 onAddItem={handleChange}
                 onChange={handleChange}
+                {...rest}
             />
-            <Divider />
-        </div>
-    );
+            <Text>
+                Combo profiles are used to determine the combo and conversion events as well as the combos found by the <b>Replay Processor</b>.
+                You can create new profiles by typing a new profile name in the dropdown.
+            </Text>
+        </Field>
+    </Outer>
+   );
 };

--- a/src/renderer/components/combos/ProfileSelection.tsx
+++ b/src/renderer/components/combos/ProfileSelection.tsx
@@ -4,7 +4,8 @@ import styled from "styled-components";
 
 import { Dropdown } from "semantic-ui-react";
 import { Text, Label, Field } from "../Form";
-import { lighten } from "polished";
+import { lighten, darken } from "polished";
+import { ThemeMode, useTheme } from "@/styles";
 
 const generateOptions = (opts: string[]) => {
     return opts.map(o => ({
@@ -14,18 +15,24 @@ const generateOptions = (opts: string[]) => {
     }));
 };
 
-const Outer = styled.div`
+const Outer = styled.div<{
+    themeName: string;
+}>`
 padding: 0 2rem;
 border-radius: 0.5rem;
-background-color: ${({theme}) => lighten(0.05, theme.background)};
+background-color: ${(p) => {
+    const adjust = p.themeName === ThemeMode.DARK ? lighten : darken;
+    return adjust(0.05, p.theme.background);
+}};
 `;
 
 export const ProfileSelector = (props: any) => {
+    const theme = useTheme();
     const { initialOptions, value, onChange, ...rest } = props;
     const options = generateOptions(initialOptions);
     const handleChange = (_: any, { value }: any) => onChange(value);
     return (
-    <Outer>
+    <Outer themeName={theme.themeName}>
         <Field>
            <Label>Current Profile</Label>
             <Dropdown

--- a/src/renderer/components/gamecube/ButtonPicker.tsx
+++ b/src/renderer/components/gamecube/ButtonPicker.tsx
@@ -28,9 +28,9 @@ export const ButtonPicker: React.FC<{
         setOpened(false);
     };
     const ButtonTextContainer = styled.div`
-    font-size: 26px;
+    font-size: 2em;
     text-align: center;
-    margin-bottom: 20px;
+    margin-bottom: 2em;
     `;
     return (
         <Modal

--- a/src/renderer/components/layout/MenuIcon.tsx
+++ b/src/renderer/components/layout/MenuIcon.tsx
@@ -9,14 +9,14 @@ const OuterMenuIcon = styled.div<{
     active?: boolean;
 }>`
     position: relative;
-    height: 70px;
+    height: 7rem;
     width: 100%;
     color: ${({ theme }) => transparentize(0.5, theme.foreground)};
     display: flex;
     justify-content: center;
     align-items: center;
-    font-size: 25px;
-    border-left: solid 4px transparent;
+    font-size: 2.5rem;
+    border-left: solid 0.4rem transparent;
     ${(props) => props.active && `
     color: ${props.theme.foreground};
     border-left-color: ${props.theme.foreground};

--- a/src/renderer/components/recorder/PlaybackQueueItem.tsx
+++ b/src/renderer/components/recorder/PlaybackQueueItem.tsx
@@ -27,7 +27,6 @@ background-color: ${p => {
 .remove-icon {
     cursor: pointer;
     opacity: 0;
-    transition: all 0.2s ease-in-out;
     padding: 5px;
 }
 ${p => p.isDragging && `

--- a/src/renderer/containers/Automator/ActionInputs.tsx
+++ b/src/renderer/containers/Automator/ActionInputs.tsx
@@ -44,7 +44,7 @@ const ActionComponentBlock = (props: any) => {
     `;
     return (
         <Outer {...rest}>
-            <div style={{padding: "5px"}}>{icon}</div>
+            <div>{icon}</div>
             <Content>
                 <div>{header}</div>
                 {children && <div style={{ margin: "10px 0" }}>{children}</div>}

--- a/src/renderer/containers/Automator/EventActions.tsx
+++ b/src/renderer/containers/Automator/EventActions.tsx
@@ -51,7 +51,7 @@ const mapEventToName: { [eventName: string]: string } = {
   }
 */
 
-const EventHeader = styled.div`
+const EventHeader = styled.h2`
   padding: 10px 0;
   display: flex;
   align-items: center;
@@ -110,8 +110,8 @@ export const EventActions = (props: any) => {
           disabledOptions={disabledOptions}
         />
         <EventHeaderButtons>
-          <Labelled onClick={() => testRunActions(value.event, value.actions)} title="Test run"><Icon name="play" size="big" /></Labelled>
-          <Labelled onClick={onRemove} title="Remove"><Icon name="remove" size="big" /></Labelled>
+          <Labelled onClick={() => testRunActions(value.event, value.actions)} title="Test run"><Icon name="play" size="large" /></Labelled>
+          <Labelled onClick={onRemove} title="Remove"><Icon name="remove" size="large" /></Labelled>
         </EventHeaderButtons>
       </EventHeader>
       <List divided>

--- a/src/renderer/containers/Menu.tsx
+++ b/src/renderer/containers/Menu.tsx
@@ -7,7 +7,6 @@ import { Link, useRouteMatch } from "react-router-dom";
 import { Icon } from "semantic-ui-react";
 
 import { MenuIcon, MenuIconLink } from "@/components/layout/MenuIcon";
-import { isDevelopment } from "@/lib/utils";
 import { iRootState } from "@/store";
 
 const Outer = styled.div`
@@ -21,14 +20,12 @@ export const Menu: React.FC = () => {
     const match = useRouteMatch();
     const { latestPath } = useSelector((state: iRootState) => state.tempContainer);
     const settingsPage = latestPath.settings || "/settings";
-    const isWindows = process.platform === "win32";
-    const showRecorderPage = isDevelopment || isWindows;
     return (
         <Outer>
             <div>
                 <MenuIconLink to={`${match.url}/automator`} label="Automator"><Icon name="bolt" /></MenuIconLink>
                 <MenuIconLink to={`${match.url}/processor`} label="Replay Processor"><Icon name="fast forward" /></MenuIconLink>
-                <MenuIconLink to={`${match.url}/recorder`} label="Game Recorder" hidden={!showRecorderPage}><Icon name="record" /></MenuIconLink>
+                <MenuIconLink to={`${match.url}/recorder`} label="Playback Queue"><Icon name="video play" /></MenuIconLink>
                 {/* <MenuIconLink to={`${match.url}/streamer`} label="Stream Assistant"><Icon name="tv" /></MenuIconLink> */}
             </div>
             <div>

--- a/src/renderer/containers/Menu.tsx
+++ b/src/renderer/containers/Menu.tsx
@@ -25,7 +25,7 @@ export const Menu: React.FC = () => {
             <div>
                 <MenuIconLink to={`${match.url}/automator`} label="Automator"><Icon name="bolt" /></MenuIconLink>
                 <MenuIconLink to={`${match.url}/processor`} label="Replay Processor"><Icon name="fast forward" /></MenuIconLink>
-                <MenuIconLink to={`${match.url}/recorder`} label="Playback Queue"><Icon name="video play" /></MenuIconLink>
+                <MenuIconLink to={`${match.url}/recorder`} label="Playback Queue"><Icon name="list" /></MenuIconLink>
                 {/* <MenuIconLink to={`${match.url}/streamer`} label="Stream Assistant"><Icon name="tv" /></MenuIconLink> */}
             </div>
             <div>

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -101,7 +101,7 @@ export const OBSStatusBar: React.FC = () => {
                         <Icon name="circle" />{recordButtonText}
                     </RecordButton>
                 </Labelled>
-                <Button onClick={onPlay} style={{ marginLeft: "0.25em" }} disabled={dolphinQueue.length === 0}><Icon name="play" />Play</Button>
+                <Button onClick={onPlay} disabled={dolphinQueue.length === 0}><Icon name="play" />Play</Button>
             </div>
         </Outer>
     );

--- a/src/renderer/containers/Recorder/OBSStatusBar.tsx
+++ b/src/renderer/containers/Recorder/OBSStatusBar.tsx
@@ -31,16 +31,20 @@ const recordingOptions = {
     },
 };
 
-const Outer = styled.div`
+const Outer = styled.div<{
+    isDev: boolean;
+}>`
 display: flex;
+flex-grow: 1;
 flex-direction: row;
-justify-content: space-between;
+justify-content: ${({isDev}) => isDev ? "space-between" : "flex-end"};
 align-items: center;
 `;
 
 export const OBSStatusBar: React.FC = () => {
     const history = useHistory();
     const { recordSeparateClips } = useSelector((state: iRootState) => state.filesystem);
+    const { isDev } = useSelector((state: iRootState) => state.slippi);
     const { obsConnectionStatus, obsRecordingStatus, dolphinQueue, dolphinPlaybackFile } = useSelector((state: iRootState) => state.tempContainer);
     const dispatch = useDispatch<Dispatch>();
 
@@ -78,8 +82,8 @@ export const OBSStatusBar: React.FC = () => {
         recordValue === RecordingMethod.SEPARATE ? "Record each item as a separate video" : "Record all items together as a single video";
     const options = Object.entries(recordingOptions).map(([key, val]) => ({...val, value: key}));
     return (
-        <Outer>
-            <ConnectionStatusDisplay
+        <Outer isDev={isDev}>
+            {isDev && <ConnectionStatusDisplay
                 icon={obsLogo}
                 iconHoverText="Open OBS settings"
                 onIconClick={() => history.push("/settings/obs-settings")}
@@ -88,9 +92,9 @@ export const OBSStatusBar: React.FC = () => {
                 color={color}
             >
                 {innerText}
-            </ConnectionStatusDisplay>
+            </ConnectionStatusDisplay>}
             <div>
-                <Labelled title={recordingButtonTitle} disabled={!recordButtonDisabled}>
+                {isDev && <Labelled title={recordingButtonTitle} disabled={!recordButtonDisabled}>
                     <RecordButton
                         onClick={onRecord}
                         disabled={recordButtonDisabled}
@@ -100,8 +104,8 @@ export const OBSStatusBar: React.FC = () => {
                     >
                         <Icon name="circle" />{recordButtonText}
                     </RecordButton>
-                </Labelled>
-                <Button onClick={onPlay} disabled={dolphinQueue.length === 0}><Icon name="play" />Play</Button>
+                </Labelled>}
+                <Button primary={true} onClick={onPlay} disabled={dolphinQueue.length === 0}><Icon name="play" />Play</Button>
             </div>
         </Outer>
     );

--- a/src/renderer/containers/Settings/ComboForm/ComboForm.tsx
+++ b/src/renderer/containers/Settings/ComboForm/ComboForm.tsx
@@ -27,9 +27,9 @@ export const ComboForm: React.FC<{
     const ButtonContainer: React.FC<{
         submitting: boolean;
         form: any;
-    }> = ({ submitting, form }) => {
+    }> = ({ submitting }) => {
         const OuterContainer = styled.div`
-        padding: 10px 0;
+        padding: 2rem 0;
         & > button {
             margin-bottom: 3px !important;
         }
@@ -41,21 +41,13 @@ export const ComboForm: React.FC<{
                     Save Profile
                 </Button>
                 <Button
-                    type="button"
-                    onClick={form.reset}
-                    disabled={submitting}
-                >
-                    <Icon name="undo" />
-                    Discard Changes
-                </Button>
-                <Button
                     negative={true}
                     type="button"
                     onClick={props.onDelete}
                 >
                     <Icon name="trash" />
                     Delete Profile
-            </Button>
+                </Button>
             </OuterContainer>
         );
     };

--- a/src/renderer/containers/Settings/ComboForm/ComboForm.tsx
+++ b/src/renderer/containers/Settings/ComboForm/ComboForm.tsx
@@ -30,8 +30,14 @@ export const ComboForm: React.FC<{
     }> = ({ submitting }) => {
         const OuterContainer = styled.div`
         padding: 2rem 0;
+        display: flex;
+        justify-content: space-between;
         & > button {
             margin-bottom: 3px !important;
+        }
+        .delete-button:hover {
+            background-color: #d01919;
+            color: white;
         }
         `;
         return (
@@ -41,7 +47,7 @@ export const ComboForm: React.FC<{
                     Save Profile
                 </Button>
                 <Button
-                    negative={true}
+                    className="delete-button"
                     type="button"
                     onClick={props.onDelete}
                 >

--- a/src/renderer/containers/Settings/ComboForm/FormAdapters.tsx
+++ b/src/renderer/containers/Settings/ComboForm/FormAdapters.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import styled from "styled-components";
+
 import { Toggle } from "@/components/Form";
 import { Checkbox, Form as SemanticForm, Input } from "semantic-ui-react";
 
@@ -27,13 +29,19 @@ export const SemanticCheckboxInput = (props: any) => {
     );
 };
 
+const StyledInput = styled(Input)`
+&&& input {
+    width: 20px !important;
+}
+`;
+
 export const SemanticInput = (props: any) => {
     const { inputLabel, input, meta, ...rest } = props;
     return (
         <SemanticForm.Field error={meta.error && meta.touched}>
             {/* <RenderCount /> */}
             {inputLabel && <label>{inputLabel}</label>}
-            <Input {...input} {...rest} />
+            <StyledInput {...input} {...rest} />
             {meta.error && meta.touched && (
                 <span style={{ color: "red" }}>{meta.error}</span>
             )}

--- a/src/renderer/containers/Settings/FilterOptions.tsx
+++ b/src/renderer/containers/Settings/FilterOptions.tsx
@@ -31,8 +31,6 @@ export const FilterOptions = () => {
     return (
         <FormContainer>
             <PageHeader>Combo Filter</PageHeader>
-            <p>These options determine when the <b>combo occurs</b> and <b>conversion occurs</b> events trigger as well as combos found by the <b>Replay Processor</b>.
-            Create new profiles by typing a new profile name in the dropdown below.</p>
             <ProfileSelector initialOptions={profileOptions} value={currentProfile} onChange={setProfile} />
             <ComboForm initialValues={initial} onSubmit={onSubmit} onDelete={onDelete} />
         </FormContainer>

--- a/src/renderer/containers/Settings/OBSSettings.tsx
+++ b/src/renderer/containers/Settings/OBSSettings.tsx
@@ -56,7 +56,7 @@ export const OBSSettings = () => {
                 <Field>
                     <Label>Websocket Password</Label>
                     <Form.Input
-                        icon={<Icon name="eye" link={true} onClick={togglePass} />}
+                        icon={<Icon name={showPass ? "eye slash" : "eye"} link={true} onClick={togglePass} />}
                         type={showPass ? "text" : "password"}
                         placeholder="Password"
                         value={obsPassword}

--- a/src/renderer/containers/Settings/OBSSettings.tsx
+++ b/src/renderer/containers/Settings/OBSSettings.tsx
@@ -44,7 +44,7 @@ export const OBSSettings = () => {
                 />
                 :
                 <Form onSubmit={connectToOBSAndNotify}>
-                    <CustomField>
+                    <CustomField padding="bottom">
                         <div>
                             <Label>IP Address</Label>
                             <Form.Input

--- a/src/renderer/containers/Settings/OBSSettings.tsx
+++ b/src/renderer/containers/Settings/OBSSettings.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Button, Form, Icon } from "semantic-ui-react";
 
@@ -9,6 +10,12 @@ import { Dispatch, iRootState } from "@/store";
 
 import { Field, FormContainer, Label, PageHeader } from "@/components/Form";
 import OBSLogo from "@/styles/images/obs.png";
+
+const CustomField = styled(Field)`
+display: grid;
+grid-gap: 2rem;
+grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr) );
+`;
 
 export const OBSSettings = () => {
     const { obsAddress, obsPort, obsPassword } = useSelector((state: iRootState) => state.slippi);
@@ -24,48 +31,50 @@ export const OBSSettings = () => {
     };
 
     return (
-    <FormContainer>
-        <PageHeader>OBS Configuration</PageHeader>
-        {obsConnected ?
-            <ConnectionStatusCard
-                header={header}
-                subHeader={subHeader}
-                userImage={OBSLogo}
-                statusColor={color}
-                onDisconnect={() => obsConnection.disconnect()}
-                shouldPulse={obsConnected}
-            />
-            :
-            <Form onSubmit={connectToOBSAndNotify}>
-                <Field>
-                    <Label>IP Address</Label>
-                    <Form.Input
-                        placeholder="localhost"
-                        value={obsAddress}
-                        onChange={(e) => { dispatch.slippi.setOBSAddress(e.target.value); }}
-                    />
-                </Field>
-                <Field>
-                    <Label>Port</Label>
-                    <Form.Input
-                        placeholder="4444"
-                        value={obsPort}
-                        onChange={(e) => { dispatch.slippi.setOBSPort(e.target.value); }}
-                    />
-                </Field>
-                <Field>
-                    <Label>Websocket Password</Label>
-                    <Form.Input
-                        icon={<Icon name={showPass ? "eye slash" : "eye"} link={true} onClick={togglePass} />}
-                        type={showPass ? "text" : "password"}
-                        placeholder="Password"
-                        value={obsPassword}
-                        onChange={(e) => { dispatch.slippi.setOBSPassword(e.target.value); }}
-                    />
-                </Field>
-                <Button primary type="submit">Connect</Button>
-            </Form>
-        }
-    </FormContainer>
+        <FormContainer>
+            <PageHeader>OBS Configuration</PageHeader>
+            {obsConnected ?
+                <ConnectionStatusCard
+                    header={header}
+                    subHeader={subHeader}
+                    userImage={OBSLogo}
+                    statusColor={color}
+                    onDisconnect={() => obsConnection.disconnect()}
+                    shouldPulse={obsConnected}
+                />
+                :
+                <Form onSubmit={connectToOBSAndNotify}>
+                    <CustomField>
+                        <div>
+                            <Label>IP Address</Label>
+                            <Form.Input
+                                placeholder="localhost"
+                                value={obsAddress}
+                                onChange={(e) => { dispatch.slippi.setOBSAddress(e.target.value); }}
+                            />
+                        </div>
+                        <div>
+                            <Label>Port</Label>
+                            <Form.Input
+                                placeholder="4444"
+                                value={obsPort}
+                                onChange={(e) => { dispatch.slippi.setOBSPort(e.target.value); }}
+                            />
+                        </div>
+                    </CustomField>
+                    <Field>
+                        <Label>Websocket Password</Label>
+                        <Form.Input
+                            icon={<Icon name={showPass ? "eye slash" : "eye"} link={true} onClick={togglePass} />}
+                            type={showPass ? "text" : "password"}
+                            placeholder="Password"
+                            value={obsPassword}
+                            onChange={(e) => { dispatch.slippi.setOBSPassword(e.target.value); }}
+                        />
+                    </Field>
+                    <Button primary type="submit">Connect</Button>
+                </Form>
+            }
+        </FormContainer>
     );
 };

--- a/src/renderer/containers/Settings/PlaybackSettings.tsx
+++ b/src/renderer/containers/Settings/PlaybackSettings.tsx
@@ -15,7 +15,7 @@ export const PlaybackSettings: React.FC = () => {
     return (
         <FormContainer>
             <PageHeader>Playback</PageHeader>
-            <Field>
+            <Field padding="bottom">
                 <Label>Melee ISO File</Label>
                 <FileInput
                     value={meleeIsoPath}

--- a/src/renderer/containers/Settings/Settings.tsx
+++ b/src/renderer/containers/Settings/Settings.tsx
@@ -30,6 +30,7 @@ const StyledMenuItem = styled(Menu.Item) <{
     header: boolean;
 }>`
 &&& {
+    font-size: 1.2em;
     color: ${({ theme }) => theme.foreground} !important;
     margin-top: 2px !important;
     margin-bottom: 2px !important;

--- a/src/renderer/containers/Settings/Settings.tsx
+++ b/src/renderer/containers/Settings/Settings.tsx
@@ -30,10 +30,10 @@ const StyledMenuItem = styled(Menu.Item) <{
     header: boolean;
 }>`
 &&& {
-    font-size: 1.2em;
+    font-size: 1.4rem !important;
     color: ${({ theme }) => theme.foreground} !important;
-    margin-top: 2px !important;
-    margin-bottom: 2px !important;
+    margin-top: 0.2rem !important;
+    margin-bottom: 0.2rem !important;
     &.active {
         background: ${({ theme }) => transparentize(0.05, theme.foreground3)} !important;
     }
@@ -42,16 +42,16 @@ const StyledMenuItem = styled(Menu.Item) <{
     }
     ${p => p.header && `
     font-variant: all-small-caps !important;
-    font-size: 15px !important;
+    font-size: 1.6rem !important;
     `}
 }
 `;
 
 const BottomMenuSection = styled.div`
-padding-top: 10px;
-padding-bottom: 10px;
-border-top: solid 1px ${({ theme }) => theme.foreground3};
-margin-top: 20px
+padding-top: 1rem;
+padding-bottom: 1rem;
+border-top: solid 0.1rem ${({ theme }) => theme.foreground3};
+margin-top: 2rem;
 `;
 
 const MenuColumn = styled.div`
@@ -61,7 +61,7 @@ overflow-y: auto;
 height: 100vh;
 color: ${({ theme }) => theme.foreground};
 background-color: ${({ theme }) => theme.background};
-border-right: solid 1px ${({ theme }) => theme.background3};
+border-right: solid 0.1rem ${({ theme }) => theme.background3};
 @media ${device.mobileL} {
     flex-basis: 40%;
 }
@@ -77,7 +77,7 @@ flex-basis: 0%;
 overflow: hidden;
 overflow-y: auto;
 height: 100vh;
-padding-left: 25px;
+padding-left: 2.5rem;
 @media ${device.mobileL} {
     flex-basis: 70%;
 }
@@ -85,9 +85,9 @@ padding-left: 25px;
     flex-basis: 75%;
 }
 & > div {
-    padding-bottom: 50px;
-    padding-top: 50px;
-    padding-right: 100px;
+    padding-bottom: 5rem;
+    padding-top: 5rem;
+    padding-right: 10rem;
 }
 `;
 const StyledMenu = styled(Menu)`
@@ -97,7 +97,7 @@ const StyledMenu = styled(Menu)`
     a.item {
         & > i.icon {
             float: left;
-            margin-right: 10px;
+            margin-right: 1rem;
             margin-left: 0;
         }
     }
@@ -108,19 +108,19 @@ display: flex;
 flex-direction: column;
 justify-content: space-between;
 height: 100%;
-padding: 50px;
+padding: 5rem;
 @media ${device.mobileL} {
-    padding-top: 20px;
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-top: 2rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
     padding-bottom: 0;
 }
 `;
 const CloseButton = styled.div`
-    font-size: 25px;
+    font-size: 2rem;
     position: fixed;
-    top: 20px;
-    right: 40px;
+    top: 2rem;
+    right: 4rem;
 `;
 
 export const SettingsPage: React.FC<{

--- a/src/renderer/containers/processor/ProcessorStatusBar.tsx
+++ b/src/renderer/containers/processor/ProcessorStatusBar.tsx
@@ -41,7 +41,7 @@ const StopButton = styled(Button)`
 export const ProcessorStatusBar: React.FC = () => {
     const { comboFinderPercent, comboFinderLog, comboFinderProcessing } = useSelector((state: iRootState) => state.tempContainer);
     const { comboProfiles } = useSelector((state: iRootState) => state.slippi);
-    const { openCombosWhenDone, includeSubFolders, deleteFilesWithNoCombos, renameFiles, findCombos, highlightMethod,
+    const { includeSubFolders, deleteFilesWithNoCombos, renameFiles, findCombos, highlightMethod,
         renameFormat, findComboProfile } = useSelector((state: iRootState) => state.highlights);
     const { inputButtonCombo, inputButtonPreInputFrames, inputButtonPostInputFrames, inputButtonHoldUnits,
         inputButtonHoldAmount, inputButtonLockoutSecs, inputButtonHold,
@@ -82,7 +82,6 @@ export const ProcessorStatusBar: React.FC = () => {
             includeSubFolders,
             outputFile: combosFilePath,
             renameTemplate: renameFormat,
-            openCombosWhenDone,
             config: findCombos && highlightMethod === FindComboOption.BUTTON_INPUTS ? buttonConfig : comboConfig,
         };
         startProcessing(options);

--- a/src/renderer/containers/processor/ProcessorStatusBar.tsx
+++ b/src/renderer/containers/processor/ProcessorStatusBar.tsx
@@ -10,8 +10,6 @@ import { mapConfigurationToFilterSettings } from "@/lib/profile";
 import { ComboFilterSettings, Input } from "@vinceau/slp-realtime";
 import { ButtonInputOptions, ComboOptions, FileProcessorOptions, FindComboOption } from "common/fileProcessor";
 
-const isWindows = process.platform === "win32";
-
 const Outer = styled.div`
 display: flex;
 flex-direction: row;
@@ -75,7 +73,6 @@ export const ProcessorStatusBar: React.FC = () => {
         const comboConfig: ComboOptions = {
             deleteZeroComboFiles: deleteFilesWithNoCombos,
             findComboCriteria: converted,
-            openCombosWhenDone: isWindows && openCombosWhenDone,
         };
 
         const options: FileProcessorOptions = {
@@ -85,6 +82,7 @@ export const ProcessorStatusBar: React.FC = () => {
             includeSubFolders,
             outputFile: combosFilePath,
             renameTemplate: renameFormat,
+            openCombosWhenDone,
             config: findCombos && highlightMethod === FindComboOption.BUTTON_INPUTS ? buttonConfig : comboConfig,
         };
         startProcessing(options);

--- a/src/renderer/containers/processor/ProcessorStatusBar.tsx
+++ b/src/renderer/containers/processor/ProcessorStatusBar.tsx
@@ -33,8 +33,8 @@ font-size: 20px;
 margin-right: 10px;
 `;
 
-const ButtonContainer = styled.div`
-.stop-button:hover {
+const StopButton = styled(Button)`
+&&&:hover {
     background-color: #d01919;
     color: white;
 }
@@ -100,19 +100,19 @@ export const ProcessorStatusBar: React.FC = () => {
                 </>
                 }
             </ProcessStatus>
-            <ButtonContainer>
+            <div>
                 {comboFinderProcessing ?
-                    <Button className="stop-button" type="button" onClick={() => stopProcessing()}>
+                    <StopButton type="button" onClick={() => stopProcessing()}>
                         <Icon name="stop" />
                             Stop processing
-                    </Button>
+                    </StopButton>
                     :
                     <Button primary={true} type="button" onClick={handleProcessClick} disabled={processBtnDisabled}>
                         <Icon name="fast forward" />
                             Process replays
                     </Button>
                 }
-            </ButtonContainer>
+            </div>
         </Outer>
     );
 };

--- a/src/renderer/containers/processor/ProcessorStatusBar.tsx
+++ b/src/renderer/containers/processor/ProcessorStatusBar.tsx
@@ -33,6 +33,13 @@ font-size: 20px;
 margin-right: 10px;
 `;
 
+const ButtonContainer = styled.div`
+.stop-button:hover {
+    background-color: #d01919;
+    color: white;
+}
+`;
+
 export const ProcessorStatusBar: React.FC = () => {
     const { comboFinderPercent, comboFinderLog, comboFinderProcessing } = useSelector((state: iRootState) => state.tempContainer);
     const { comboProfiles } = useSelector((state: iRootState) => state.slippi);
@@ -93,9 +100,9 @@ export const ProcessorStatusBar: React.FC = () => {
                 </>
                 }
             </ProcessStatus>
-            <div>
+            <ButtonContainer>
                 {comboFinderProcessing ?
-                    <Button negative={true} type="button" onClick={() => stopProcessing()}>
+                    <Button className="stop-button" type="button" onClick={() => stopProcessing()}>
                         <Icon name="stop" />
                             Stop processing
                     </Button>
@@ -105,7 +112,7 @@ export const ProcessorStatusBar: React.FC = () => {
                             Process replays
                     </Button>
                 }
-            </div>
+            </ButtonContainer>
         </Outer>
     );
 };

--- a/src/renderer/containers/processor/ProgressBar.tsx
+++ b/src/renderer/containers/processor/ProgressBar.tsx
@@ -14,7 +14,7 @@ left: 0;
 height: 100%;
 width: ${p => p.percent}%;
 background-color: ${({theme}) => theme.secondary};
-opacity: 0.1;
+opacity: 0.2;
 transition: all 0.5s ease-in-out;
 `;
 

--- a/src/renderer/lib/fileProcessor.ts
+++ b/src/renderer/lib/fileProcessor.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 import Worker from "worker-loader!common/workers/fileProcessor.worker";
 
-import { dispatcher } from "@/store";
+import { store, dispatcher } from "@/store";
 import { FileProcessorOptions } from "common/fileProcessor";
 import { secondsToString } from "common/utils";
 import { CompletePayload, FileProcessorParentMessage, FileProcessorWorkerMessage, ProgressingPayload } from "common/workers/fileProcessor.worker.types";
@@ -48,7 +48,7 @@ const handleComplete = (payload: CompletePayload): void => {
     const { options, result } = payload;
     const timeTakenStr = secondsToString(result.timeTaken);
     const numCombos = result.combosFound;
-    const openCombos = Boolean(options.openCombosWhenDone);
+    const { openCombosWhenDone } = store.getState().highlights;
     console.log(`finished generating ${numCombos} highlights in ${timeTakenStr}`);
     let message = `Processed ${result.filesProcessed} files in ${timeTakenStr}`;
     if (options.findComboOption) {
@@ -58,7 +58,7 @@ const handleComplete = (payload: CompletePayload): void => {
     dispatcher.tempContainer.setPercent(100);
     dispatcher.tempContainer.setComboLog(message);
     notify(message, `Highlight processing complete`);
-    if (openCombos && options.outputFile) {
+    if (openCombosWhenDone && options.outputFile) {
         // check if we want to open the combo file after generation
         openComboInDolphin(options.outputFile);
     }

--- a/src/renderer/lib/fileProcessor.ts
+++ b/src/renderer/lib/fileProcessor.ts
@@ -3,7 +3,7 @@ import path from "path";
 import Worker from "worker-loader!common/workers/fileProcessor.worker";
 
 import { dispatcher } from "@/store";
-import { ComboOptions, FileProcessorOptions } from "common/fileProcessor";
+import { FileProcessorOptions } from "common/fileProcessor";
 import { secondsToString } from "common/utils";
 import { CompletePayload, FileProcessorParentMessage, FileProcessorWorkerMessage, ProgressingPayload } from "common/workers/fileProcessor.worker.types";
 import { openComboInDolphin } from "./dolphin";
@@ -48,12 +48,11 @@ const handleComplete = (payload: CompletePayload): void => {
     const { options, result } = payload;
     const timeTakenStr = secondsToString(result.timeTaken);
     const numCombos = result.combosFound;
-    let openCombos = false;
+    const openCombos = Boolean(options.openCombosWhenDone);
     console.log(`finished generating ${numCombos} highlights in ${timeTakenStr}`);
     let message = `Processed ${result.filesProcessed} files in ${timeTakenStr}`;
     if (options.findComboOption) {
         message += ` and found ${numCombos} highlights`;
-        openCombos = Boolean((options.config as ComboOptions).openCombosWhenDone);
     }
     dispatcher.tempContainer.setComboFinderProcessing(false);
     dispatcher.tempContainer.setPercent(100);

--- a/src/renderer/store/models/slippi.ts
+++ b/src/renderer/store/models/slippi.ts
@@ -17,6 +17,7 @@ export interface SlippiState {
     obsAddress: string;
     obsPort: string;
     obsPassword: string;
+    isDev: boolean;
 }
 
 const defaultSettings = JSON.stringify(mapFilterSettingsToConfiguration(comboFilter.getSettings()));
@@ -31,11 +32,17 @@ const initialState: SlippiState = {
     obsAddress: "localhost",
     obsPort: "4444",
     obsPassword: "",
+    isDev: false,
 };
 
 export const slippi = createModel({
     state: initialState,
     reducers: {
+        setIsDev: (state: SlippiState, payload: boolean): SlippiState => {
+            return produce(state, draft => {
+                draft.isDev = payload;
+            });
+        },
         setOBSAddress: (state: SlippiState, payload: string): SlippiState => {
             return produce(state, draft => {
                 draft.obsAddress = payload;

--- a/src/renderer/styles/global.ts
+++ b/src/renderer/styles/global.ts
@@ -11,10 +11,16 @@ export const GlobalStyle = createGlobalStyle<{
     color: ${({ theme }) => theme.foreground };
   }
 
+  .ui.buttons {
+    font-size: 1em;
+    margin: 0;
+  }
+
   .ui.dropdown .menu>.item,
   .ui.checkbox,
   .ui.segment,
   .ui.button,
+  .ui.buttons .button,
   .ui.modal,
   .ui.form {
     font-size: 1em;

--- a/src/renderer/styles/global.ts
+++ b/src/renderer/styles/global.ts
@@ -11,6 +11,15 @@ export const GlobalStyle = createGlobalStyle<{
     color: ${({ theme }) => theme.foreground };
   }
 
+  .ui.dropdown .menu>.item,
+  .ui.checkbox,
+  .ui.segment,
+  .ui.button,
+  .ui.modal,
+  .ui.form {
+    font-size: 1em;
+  }
+
   .ui.form .file-input input[type=text] {
     width: auto !important;
   }

--- a/src/renderer/styles/index.scss
+++ b/src/renderer/styles/index.scss
@@ -9,7 +9,7 @@ html {
 }
 
 body {
-    font-size: 1.6rem;
+    font-size: 1.4em;
 }
 
 #app {

--- a/src/renderer/styles/index.scss
+++ b/src/renderer/styles/index.scss
@@ -4,6 +4,14 @@ body {
     font: caption;
 }
 
+html {
+    font-size: 62.5%;
+}
+
+body {
+    font-size: 1.6rem;
+}
+
 #app {
     height: 100%;
 }

--- a/src/renderer/views/main/AutomatorView.tsx
+++ b/src/renderer/views/main/AutomatorView.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { Icon } from "semantic-ui-react";
 
+import { FormContainer } from "@/components/Form";
 import { Automator } from "@/containers/Automator/Automator";
 import { StatusBar } from "@/containers/Automator/StatusBar";
 
@@ -15,7 +16,7 @@ const Content = styled.div`
 `;
 
 const Footer = styled.div`
-    border-top: solid 1px ${({theme}) => theme.background3};
+    border-top: solid 1px ${({ theme }) => theme.background3};
     background-color: ${props => props.theme.background};
     height: 55px;
     padding-left: 20px;
@@ -32,8 +33,10 @@ export const AutomatorView: React.FC = () => {
     return (
         <Outer>
             <Content>
-                <h1>Automator <Icon name="bolt" /></h1>
-                <Automator />
+                <FormContainer>
+                    <h1>Automator <Icon name="bolt" /></h1>
+                    <Automator />
+                </FormContainer>
             </Content>
             <Footer>
                 <StatusBar />

--- a/src/renderer/views/main/AutomatorView.tsx
+++ b/src/renderer/views/main/AutomatorView.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 import { Icon } from "semantic-ui-react";
 
-import { FormContainer } from "@/components/Form";
+import { FormContainer, Text } from "@/components/Form";
 import { Automator } from "@/containers/Automator/Automator";
 import { StatusBar } from "@/containers/Automator/StatusBar";
 
@@ -35,6 +35,7 @@ export const AutomatorView: React.FC = () => {
             <Content>
                 <FormContainer>
                     <h1>Automator <Icon name="bolt" /></h1>
+                    <Text>Automatically execute commands when an in-game event occurs</Text>
                     <Automator />
                 </FormContainer>
             </Content>

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -23,6 +23,7 @@ const Content = styled.div`
 `;
 
 const Footer = styled.div`
+    display: flex;
     border-top: solid 1px ${({ theme }) => theme.background3};
     background-color: ${props => props.theme.background};
     height: 55px;

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -113,7 +113,7 @@ export const RecorderView: React.FC = () => {
     return (
         <Outer>
             <Content>
-                <h1>Playback Queue <Icon name="video play" /></h1>
+                <h1>Playback Queue <Icon name="list" /></h1>
                 <Toolbar>
                     <div>
                         <Button type="button" onClick={loadFileHandler}>

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { darken, lighten } from "polished";
 import styled from "styled-components";
 
+import { Text } from "@/components/Form";
 import { Labelled } from "@/components/Labelled";
 import { Dispatch, iRootState } from "@/store";
 import { ThemeMode, useTheme } from "@/styles";
@@ -115,6 +116,7 @@ export const RecorderView: React.FC = () => {
         <Outer>
             <Content>
                 <h1>Playback Queue <Icon name="list" /></h1>
+                <Text margin="none">Create a playlist of replays and load them into Dolphin</Text>
                 <Toolbar>
                     <div>
                         <Button type="button" onClick={loadFileHandler}>

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -113,7 +113,7 @@ export const RecorderView: React.FC = () => {
     return (
         <Outer>
             <Content>
-                <h1>Game Recorder <Icon name="record" /></h1>
+                <h1>Playback Queue <Icon name="video play" /></h1>
                 <Toolbar>
                     <div>
                         <Button type="button" onClick={loadFileHandler}>

--- a/src/renderer/views/main/RecorderView.tsx
+++ b/src/renderer/views/main/RecorderView.tsx
@@ -17,18 +17,18 @@ import { saveQueueToFile } from "@/lib/dolphin";
 const Content = styled.div`
     display: flex;
     flex-direction: column;
-    padding: 20px;
-    height: calc(100% - 56px);
+    padding: 2rem;
+    height: calc(100% - 5.6rem);
     overflow: hidden;
     overflow-y: auto;
 `;
 
 const Footer = styled.div`
     display: flex;
-    border-top: solid 1px ${({ theme }) => theme.background3};
+    border-top: solid 0.1rem ${({ theme }) => theme.background3};
     background-color: ${props => props.theme.background};
-    height: 55px;
-    padding: 0 20px;
+    height: 5.5rem;
+    padding: 0 2rem;
 `;
 
 const Outer = styled.div`
@@ -46,18 +46,19 @@ background-color: ${p => {
         const adjust = p.themeName === ThemeMode.DARK ? lighten : darken;
         return adjust(0.05, p.theme.background);
     }};
-border-radius: 5px;
+border-radius: 0.5rem;
 overflow: hidden;
 overflow-y: auto;
 position: relative;
 `;
 
 const Toolbar = styled.div`
+padding-top: 2rem;
 display: flex;
 flex-direction: row;
 justify-content: space-between;
 align-items: center;
-margin-bottom: 10px;
+margin-bottom: 1rem;
 `;
 
 export const RecorderView: React.FC = () => {

--- a/src/renderer/views/main/ReplayProcessorView.tsx
+++ b/src/renderer/views/main/ReplayProcessorView.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { Icon } from "semantic-ui-react";
 
+import { Text } from "@/components/Form";
 import { ProcessorStatusBar } from "@/containers/processor/ProcessorStatusBar";
 import { ProgressBar } from "@/containers/processor/ProgressBar";
 import { ComboFinder } from "@/containers/Settings/ComboFinder";
@@ -36,6 +37,7 @@ export const ReplayProcessorView: React.FC = () => {
         <Outer>
             <Content>
                 <h1>Replay Processor <Icon name="fast forward" /></h1>
+                <Text>Find combos and highlights from your replay files</Text>
                 <ComboFinder />
             </Content>
             <Footer>

--- a/src/renderer/views/settings/Appearance.tsx
+++ b/src/renderer/views/settings/Appearance.tsx
@@ -11,7 +11,7 @@ export const Appearance: React.FC = () => {
     return (
         <FormContainer>
             <PageHeader>Appearance</PageHeader>
-            <Field>
+            <Field padding="bottom">
                 <Toggle
                     value={themeName === "dark"}
                     onChange={onOpenChange}

--- a/src/renderer/views/settings/InfoView.tsx
+++ b/src/renderer/views/settings/InfoView.tsx
@@ -7,8 +7,9 @@ import styled from "styled-components";
 import supporters from "raw-loader!../../../../SUPPORTERS.md";
 
 import clippiLogo from "../../../../build/icon.png";
+import { FormContainer } from "@/components/Form";
 
-const Container = styled.div`
+const Container = styled(FormContainer)`
 text-align: center;
 
 ul {
@@ -18,8 +19,8 @@ ul {
 `;
 
 const Content = styled.div`
+padding-bottom: 2rem;
 p {
-    max-width: 600px;
     margin-left: auto;
     margin-right: auto;
 }
@@ -27,8 +28,8 @@ p {
 
 const Footer = styled.div`
 font-style: italic;
-font-size: 16px;
-margin-top: 40px;
+font-size: 1.6rem;
+margin-top: 4rem;
 `;
 
 const Logo = styled.img`

--- a/src/renderer/views/settings/InfoView.tsx
+++ b/src/renderer/views/settings/InfoView.tsx
@@ -2,6 +2,9 @@ import React from "react";
 
 import ReactMarkdown from "react-markdown";
 
+import { Dispatch, iRootState } from "@/store";
+import { useDispatch, useSelector } from "react-redux";
+
 import styled from "styled-components";
 
 import supporters from "raw-loader!../../../../SUPPORTERS.md";
@@ -38,9 +41,15 @@ width: 6.4rem;
 `;
 
 export const InfoView: React.FC = () => {
+    const { isDev } = useSelector((state: iRootState) => state.slippi);
+    const dispatch = useDispatch<Dispatch>();
+    const handleLogoClick = () => {
+        console.log(isDev ? "Disabling dev" : "Enabling dev");
+        dispatch.slippi.setIsDev(!isDev);
+    };
     return (
         <Container>
-            <Logo src={clippiLogo} />
+            <Logo src={clippiLogo} onClick={handleLogoClick} />
             <h1>Project Clippi</h1>
             <Content>
                 <h3>Version {__VERSION__}</h3>

--- a/src/renderer/views/settings/InfoView.tsx
+++ b/src/renderer/views/settings/InfoView.tsx
@@ -6,6 +6,8 @@ import styled from "styled-components";
 
 import supporters from "raw-loader!../../../../SUPPORTERS.md";
 
+import clippiLogo from "../../../../build/icon.png";
+
 const Container = styled.div`
 text-align: center;
 
@@ -29,9 +31,15 @@ font-size: 16px;
 margin-top: 40px;
 `;
 
+const Logo = styled.img`
+height: 6.4rem;
+width: 6.4rem;
+`;
+
 export const InfoView: React.FC = () => {
     return (
         <Container>
+            <Logo src={clippiLogo} />
             <h1>Project Clippi</h1>
             <Content>
                 <h3>Version {__VERSION__}</h3>

--- a/src/renderer/views/settings/InfoView.tsx
+++ b/src/renderer/views/settings/InfoView.tsx
@@ -35,21 +35,33 @@ font-size: 1.6rem;
 margin-top: 4rem;
 `;
 
-const Logo = styled.img`
+const Logo = styled.img<{
+    isDev: boolean;
+}>`
 height: 6.4rem;
 width: 6.4rem;
+${({isDev}) => isDev && `
+    transform: scaleX(-1);
+`}
 `;
 
+const DEV_THRESHOLD = 7;
+
 export const InfoView: React.FC = () => {
+    const [ clickCount, setClickCount ] = React.useState(0);
     const { isDev } = useSelector((state: iRootState) => state.slippi);
     const dispatch = useDispatch<Dispatch>();
     const handleLogoClick = () => {
-        console.log(isDev ? "Disabling dev" : "Enabling dev");
-        dispatch.slippi.setIsDev(!isDev);
+        setClickCount(clickCount + 1);
+        if (clickCount === DEV_THRESHOLD - 1) {
+            console.log(isDev ? "Disabling dev" : "Enabling dev");
+            dispatch.slippi.setIsDev(!isDev);
+            setClickCount(0);
+        }
     };
     return (
         <Container>
-            <Logo src={clippiLogo} onClick={handleLogoClick} />
+            <Logo isDev={isDev} src={clippiLogo} onClick={handleLogoClick} />
             <h1>Project Clippi</h1>
             <Content>
                 <h3>Version {__VERSION__}</h3>


### PR DESCRIPTION
This PR begins a migration away from `px` as units, towards `rem` or `em` instead. This allows for better reasoning of sizes across different operating systems which should lead to a more consistent UI. This PR also enables zooming of the app and other miscellaneous style changes and fixes, and renames the Game Recorder page to Playback Queue.