### PR TITLE
Disable processing if filename is invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "electron-store": "^5.1.1",
     "emotion-theming": "^10.0.27",
     "fast-glob": "^3.1.1",
+    "filename-reserved-regex": "^2.0.0",
+    "filenamify": "^4.1.0",
     "final-form": "^4.18.6",
     "final-form-arrays": "^3.0.2",
     "formatter": "^0.4.1",

--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -18,6 +18,7 @@ import {
   StockType,
   Metadata,
 } from "@vinceau/slp-realtime";
+import { sanitizeFilename } from "./utils";
 
 const exampleFilename = "Game_20190323T111317.slp";
 
@@ -187,8 +188,8 @@ export const generateGlobalContext = (context?: Context, date?: Moment): Context
   const m = date ? date : moment();
   const d = m.toDate();
   const newContext = {
-    date: d.toLocaleDateString(),
-    time: d.toLocaleTimeString(),
+    date: sanitizeFilename(d.toLocaleDateString()),
+    time: sanitizeFilename(d.toLocaleTimeString()),
   };
   for (const snip of momentSnippets) {
     newContext[snip] = m.local().format(snip);

--- a/src/common/fileProcessor.ts
+++ b/src/common/fileProcessor.ts
@@ -119,6 +119,11 @@ export class FileProcessor {
     return this.processing;
   }
 
+  public reset(): void {
+    this.processing = false;
+    this.stopRequested = false;
+  }
+
   public stop(): void {
     this.stopRequested = true;
   }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,6 +1,8 @@
 import fs from "fs-extra";
 import path from "path";
 import trash from "trash";
+import filenamify from "filenamify";
+import filenameReservedRegex from "filename-reserved-regex";
 
 import { EOL } from "os";
 
@@ -120,4 +122,44 @@ export const secondsToFrames = (secs: number): number => {
 
 export const millisToFrames = (ms: number): number => {
   return secondsToFrames(ms / 1000);
+};
+
+export const sanitizeFilename = (name: string): string => {
+  return filenamify(name, {
+    replacement: ".",
+  });
+};
+
+export const invalidFilename = (name: string, options?: { allowPaths?: boolean }): boolean => {
+  if (options && options.allowPaths) {
+    // Check if any parts of the folder path are invalid
+    console.log(`Checking name: >>>${name}<<<`);
+    const norm = path.normalize(name);
+    console.log(`Normalised name: >>>${norm}<<<`);
+    const parts = norm.split(path.sep);
+    for (const p of parts) {
+      console.log(`Checking part: ${p}`);
+      if (p && !validFilename(p)) {
+        console.log(`${p} is invalid`);
+        return true;
+      }
+    }
+    console.log(`${name} is valid`);
+    return false;
+  }
+
+  return !validFilename(name);
+};
+
+const validFilename = (name: string): boolean => {
+  if (!name) {
+    return false;
+  }
+  if (filenameReservedRegex().test(name) || filenameReservedRegex.windowsNames().test(name)) {
+    return false;
+  }
+  if (/^\.\.?$/.test(name)) {
+    return false;
+  }
+  return true;
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -143,6 +143,8 @@ export const invalidFilename = (name: string, options?: { allowPaths?: boolean }
   return !validFilename(name);
 };
 
+// Based on code from: https://github.com/sindresorhus/valid-filename
+// Checks for filename validity but without the length check
 const validFilename = (name: string): boolean => {
   if (!name) {
     return false;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -133,19 +133,11 @@ export const sanitizeFilename = (name: string): string => {
 export const invalidFilename = (name: string, options?: { allowPaths?: boolean }): boolean => {
   if (options && options.allowPaths) {
     // Check if any parts of the folder path are invalid
-    console.log(`Checking name: >>>${name}<<<`);
-    const norm = path.normalize(name);
-    console.log(`Normalised name: >>>${norm}<<<`);
-    const parts = norm.split(path.sep);
-    for (const p of parts) {
-      console.log(`Checking part: ${p}`);
-      if (p && !validFilename(p)) {
-        console.log(`${p} is invalid`);
-        return true;
-      }
-    }
-    console.log(`${name} is valid`);
-    return false;
+    return path
+      .normalize(name) // Make sure the path separators are correct
+      .split(path.sep) // Split on each path component
+      .filter((p) => p.length > 0) // Make sure we have something to check
+      .some((p) => !validFilename(p)); // Check if any of them are invalid
   }
 
   return !validFilename(name);

--- a/src/common/workers/fileProcessor.worker.ts
+++ b/src/common/workers/fileProcessor.worker.ts
@@ -1,5 +1,4 @@
-// Worker.ts
-// import fs from "fs-extra";
+// File processor worker
 
 import { FileProcessor, FileProcessorOptions, ProcessOutput, ProcessResult } from "../fileProcessor";
 import {
@@ -10,10 +9,6 @@ import {
 } from "./fileProcessor.worker.types";
 
 const fileProcessor = new FileProcessor();
-
-// const readFiles = async (dir: string) => {
-//     return await fs.readdir(dir);
-// };
 
 const startProcessing = async (options: FileProcessorOptions): Promise<ProcessOutput> => {
   const callback = (index: number, total: number, filename: string, result: ProcessResult): void => {
@@ -32,12 +27,8 @@ const startProcessing = async (options: FileProcessorOptions): Promise<ProcessOu
   return fileProcessor.process(options, callback);
 };
 
-// Worker.ts
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx: Worker = self as any;
-
-// Post data to parent thread
-// ctx.postMessage({ foo: "foo" });
 
 // Respond to message from parent thread
 ctx.addEventListener("message", async (event) => {
@@ -73,12 +64,11 @@ ctx.addEventListener("message", async (event) => {
             message: err.message,
           },
         });
+        fileProcessor.reset();
       }
       break;
     case FileProcessorParentMessage.STOP:
       fileProcessor.stop();
       break;
   }
-  // const res = await readFiles(".");
-  // console.log(res);
 });

--- a/src/common/workers/fileProcessor.worker.ts
+++ b/src/common/workers/fileProcessor.worker.ts
@@ -55,15 +55,25 @@ ctx.addEventListener("message", async (event) => {
       }
 
       // Start the processing
-      const startPayload = event.data.payload as StartProcessingPayload;
-      const result = await startProcessing(startPayload.options);
-      ctx.postMessage({
-        type: FileProcessorWorkerMessage.COMPLETE,
-        payload: {
-          result,
-          options: startPayload.options,
-        },
-      });
+      try {
+        const startPayload = event.data.payload as StartProcessingPayload;
+        const result = await startProcessing(startPayload.options);
+        ctx.postMessage({
+          type: FileProcessorWorkerMessage.COMPLETE,
+          payload: {
+            result,
+            options: startPayload.options,
+          },
+        });
+      } catch (err) {
+        console.error(err);
+        ctx.postMessage({
+          type: FileProcessorWorkerMessage.ERROR,
+          payload: {
+            message: err.message,
+          },
+        });
+      }
       break;
     case FileProcessorParentMessage.STOP:
       fileProcessor.stop();

--- a/src/common/workers/fileProcessor.worker.types.ts
+++ b/src/common/workers/fileProcessor.worker.types.ts
@@ -4,6 +4,7 @@ export enum FileProcessorWorkerMessage {
   PROGRESS = "PROGRESS",
   BUSY = "BUSY",
   COMPLETE = "COMPLETE",
+  ERROR = "ERROR",
 }
 
 export interface ProgressingPayload {
@@ -16,6 +17,10 @@ export interface ProgressingPayload {
 export interface CompletePayload {
   result: ProcessOutput;
   options: FileProcessorOptions;
+}
+
+export interface ErrorPayload {
+  message: string;
 }
 
 export enum FileProcessorParentMessage {

--- a/src/renderer/components/RenameFiles.tsx
+++ b/src/renderer/components/RenameFiles.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from "@emotion/core";
 import * as React from "react";
 
 import insertTextAtCursor from "insert-text-at-cursor";

--- a/src/renderer/components/RenameFiles.tsx
+++ b/src/renderer/components/RenameFiles.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import * as React from "react";
 
 import insertTextAtCursor from "insert-text-at-cursor";
@@ -11,6 +13,7 @@ import { SlideReveal } from "@/components/ProcessSection";
 import { TemplatePreview } from "@/components/TemplatePreview";
 import { defaultRenameFormat } from "@/store/models/highlights";
 import { Labelled } from "./Labelled";
+import { invalidFilename } from "common/utils";
 
 const FormatLabel = styled.div`
   display: flex;
@@ -28,9 +31,12 @@ const ResetButton = styled.span`
   }
 `;
 
-const PreviewContainer = styled.p`
-  word-break: break-all;
+const PreviewContainer = styled.div`
   margin-top: 1rem;
+`;
+
+const ErrorContainer = styled.div`
+  color: red;
 `;
 
 const metadata = {
@@ -63,6 +69,7 @@ export const RenameFiles: React.FC<{
     const alreadyHasBrackets = leftChars === "{{" && rightChars === "}}";
     insertTextAtCursor(textRef.current, alreadyHasBrackets ? text : `{{${text}}}`);
   };
+  const isInvalid = invalidFilename(renameFormat, { allowPaths: true });
   return (
     <div>
       <div style={{ textAlign: "right", marginBottom: "5px" }}>
@@ -99,8 +106,14 @@ export const RenameFiles: React.FC<{
           onBlur={() => props.onChange(renameFormat)}
         />
         <PreviewContainer>
-          <b>Preview: </b>
-          <TemplatePreview template={renameFormat} metadata={metadata} />
+          {isInvalid ? (
+            <ErrorContainer>Invalid filename format. Please check that there are no invalid characters.</ErrorContainer>
+          ) : (
+            <div>
+              <b>Preview: </b>
+              <TemplatePreview template={renameFormat} metadata={metadata} />
+            </div>
+          )}
         </PreviewContainer>
       </Field>
     </div>

--- a/src/renderer/components/RenameFiles.tsx
+++ b/src/renderer/components/RenameFiles.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { css, jsx } from "@emotion/core";
+import { jsx } from "@emotion/core";
 import * as React from "react";
 
 import insertTextAtCursor from "insert-text-at-cursor";

--- a/src/renderer/components/TemplatePreview.tsx
+++ b/src/renderer/components/TemplatePreview.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import * as React from "react";
 
 import { GameStartType } from "@vinceau/slp-realtime";
@@ -9,5 +11,13 @@ export const TemplatePreview: React.FC<{
   metadata?: any;
 }> = (props) => {
   const parsedTemplate = parseFileRenameFormat(props.template, props.settings, props.metadata);
-  return <span>{parsedTemplate}</span>;
+  return (
+    <span
+      css={css`
+        word-break: break-all;
+      `}
+    >
+      {parsedTemplate}
+    </span>
+  );
 };

--- a/src/renderer/components/toasts/ProcessingError.tsx
+++ b/src/renderer/components/toasts/ProcessingError.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import React from "react";
+
+import { A } from "../ExternalLink";
+
+export const ProcessingError: React.FC<{
+  errorMessage: string;
+}> = (props) => {
+  const { errorMessage } = props;
+  const url = `https://twitter.com/ProjectClippi`;
+  return (
+    <div>
+      <h3>An error occurred during processing</h3>
+      <p>
+        Please tweet this error to <A href={url}>@ProjectClippi</A> for assistance.
+      </p>
+      <pre
+        css={css`
+          white-space: initial;
+          word-break: break-all;
+        `}
+      >
+        {errorMessage}
+      </pre>
+    </div>
+  );
+};

--- a/src/renderer/components/toasts/ToastContainer.tsx
+++ b/src/renderer/components/toasts/ToastContainer.tsx
@@ -59,6 +59,7 @@ const StyledToastContainer = styled(TC)`
     }
   }
   .Toastify__toast-body {
+    max-width: 100%;
     margin-left: 10px;
     font-size: 13px;
     font-weight: normal;

--- a/src/renderer/containers/processor/ProcessorStatusBar.tsx
+++ b/src/renderer/containers/processor/ProcessorStatusBar.tsx
@@ -9,6 +9,7 @@ import { startProcessing, stopProcessing } from "@/lib/fileProcessor";
 import { mapConfigurationToFilterSettings } from "@/lib/profile";
 import { ComboFilterSettings, Input } from "@vinceau/slp-realtime";
 import { ButtonInputOptions, ComboOptions, FileProcessorOptions, FindComboOption } from "common/fileProcessor";
+import { invalidFilename } from "common/utils";
 
 const Outer = styled.div`
   display: flex;
@@ -66,7 +67,10 @@ export const ProcessorStatusBar: React.FC = () => {
   const complete = comboFinderPercent === 100;
   const validButtonCombo =
     !findCombos || highlightMethod !== FindComboOption.BUTTON_INPUTS || inputButtonCombo.length > 0;
-  const processBtnDisabled = (!findCombos && !renameFiles) || !combosFilePath || !validButtonCombo;
+
+  // If we're renaming make sure we have a valid rename format
+  const isInvalid = renameFiles && invalidFilename(renameFormat, { allowPaths: true });
+  const processBtnDisabled = (!findCombos && !renameFiles) || !combosFilePath || !validButtonCombo || isInvalid;
 
   const handleProcessClick = () => {
     console.log(

--- a/src/renderer/declarations.d.ts
+++ b/src/renderer/declarations.d.ts
@@ -9,6 +9,7 @@ declare module "*.tiff";
 declare module "*.md";
 
 declare module "node-notifier";
+declare module "filename-reserved-regex";
 declare module "insert-text-at-cursor";
 
 declare module "formatter" {

--- a/src/renderer/lib/fileProcessor.ts
+++ b/src/renderer/lib/fileProcessor.ts
@@ -14,6 +14,7 @@ import {
 } from "common/workers/fileProcessor.worker.types";
 import { openComboInDolphin } from "./dolphin";
 import { notify } from "./utils";
+import { toastProcessingError } from "./toasts";
 
 const worker = new Worker();
 
@@ -82,6 +83,7 @@ const handleError = (payload: ErrorPayload): void => {
   const { message } = payload;
   dispatcher.tempContainer.setComboFinderProcessing(false);
   notify(message, "An error occurred during processing");
+  toastProcessingError(message);
 };
 
 export const startProcessing = (options: FileProcessorOptions): void => {

--- a/src/renderer/lib/fileProcessor.ts
+++ b/src/renderer/lib/fileProcessor.ts
@@ -10,6 +10,7 @@ import {
   FileProcessorParentMessage,
   FileProcessorWorkerMessage,
   ProgressingPayload,
+  ErrorPayload,
 } from "common/workers/fileProcessor.worker.types";
 import { openComboInDolphin } from "./dolphin";
 import { notify } from "./utils";
@@ -26,6 +27,10 @@ worker.onmessage = (event) => {
       handleProgress(progressPayload);
       break;
     case FileProcessorWorkerMessage.BUSY:
+      break;
+    case FileProcessorWorkerMessage.ERROR:
+      const errorPayload: ErrorPayload = event.data.payload;
+      handleError(errorPayload);
       break;
     case FileProcessorWorkerMessage.COMPLETE:
       const completePayload: CompletePayload = event.data.payload;
@@ -71,6 +76,12 @@ const handleComplete = (payload: CompletePayload): void => {
   } else {
     notify(message, `Highlight processing complete`);
   }
+};
+
+const handleError = (payload: ErrorPayload): void => {
+  const { message } = payload;
+  dispatcher.tempContainer.setComboFinderProcessing(false);
+  notify(message, "An error occurred during processing");
 };
 
 export const startProcessing = (options: FileProcessorOptions): void => {

--- a/src/renderer/lib/toasts.tsx
+++ b/src/renderer/lib/toasts.tsx
@@ -1,11 +1,20 @@
 import React from "react";
 
 import { NoDolphinToast } from "@/components/toasts/NoDolphinToast";
+import { ProcessingError } from "@/components/toasts/ProcessingError";
 import { toast } from "react-toastify";
 
 export const toastNoDolphin = (): void => {
   toast.error(<NoDolphinToast />, {
     autoClose: false,
     toastId: "no-dolphin-toast",
+  });
+};
+
+export const toastProcessingError = (errorMessage: string): void => {
+  toast.error(<ProcessingError errorMessage={errorMessage} />, {
+    autoClose: false,
+    toastId: "processing-error-toast",
+    closeOnClick: false,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4431,6 +4431,20 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
+  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.1.0.tgz#54d110810ae74eebfe115c1b995bd07e03cf2184"
+  integrity sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.1"
+    trim-repeated "^1.0.0"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -9474,6 +9488,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-outer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 style-loader@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.0.tgz#f78e4d49caf5018f7c03ae1886e1270124feeb0a"
@@ -9766,6 +9787,13 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 trim-trailing-lines@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
This PR adds checks to ensure filename is valid before starting the file renaming process. In addition, it adds better support for catching errors in the file processor worker thread.

This fixes #70.