### PR TITLE
Portable Mode

### DIFF
--- a/src/renderer/containers/ComboFinder.tsx
+++ b/src/renderer/containers/ComboFinder.tsx
@@ -17,6 +17,7 @@ export const ComboFinder: React.FC = () => {
   const {
     openCombosWhenDone,
     includeSubFolders,
+    makeItPortable,
     deleteFilesWithNoCombos,
     renameFiles,
     findCombos,
@@ -28,6 +29,7 @@ export const ComboFinder: React.FC = () => {
   const setRenameFiles = (checked: boolean) => dispatch.highlights.setRenameFiles(checked);
   const setFindCombos = (checked: boolean) => dispatch.highlights.setFindCombos(checked);
   const onSubfolder = (checked: boolean) => dispatch.highlights.setIncludeSubFolders(checked);
+  const onSetPortable = (checked: boolean) => dispatch.highlights.setPortable(checked);
   const onSetDeleteFiles = (checked: boolean) => dispatch.highlights.setFileDeletion(checked);
   const onSetOpenCombosWhenDone = (checked: boolean) => dispatch.highlights.setOpenCombosWhenDone(checked);
   const setCombosFilePath = (p: string) => {
@@ -64,6 +66,13 @@ export const ComboFinder: React.FC = () => {
                 fileTypeFilters={[{ name: "JSON files", extensions: ["json"] }]}
               />
             </div>
+            <Form.Field>
+              <Checkbox
+                label="Make it portable for distributability"
+                checked={makeItPortable}
+                onChange={(_, data) => onSetPortable(Boolean(data.checked))}
+              />
+            </Form.Field>
             <Form.Field>
               <Checkbox
                 label="Delete files with no highlights"

--- a/src/renderer/store/models/highlights.ts
+++ b/src/renderer/store/models/highlights.ts
@@ -7,6 +7,7 @@ export const defaultRenameFormat =
   "{{YY}}{{MM}}{{DD}}_{{HH}}{{mm}}_{{playerShortChar}}_v_{{opponentShortChar}}_({{shortStage}}).slp";
 
 export interface HighlightState {
+  makeItPortable: boolean;
   includeSubFolders: boolean;
   deleteFilesWithNoCombos: boolean;
   findCombos: boolean;
@@ -18,6 +19,7 @@ export interface HighlightState {
 }
 
 export const highlightInitialState: HighlightState = {
+  makeItPortable: false,
   includeSubFolders: false,
   deleteFilesWithNoCombos: false,
   findCombos: true,
@@ -38,6 +40,10 @@ export const highlights = createModel({
     setHighlightMethod: (state: HighlightState, payload: FindComboOption): HighlightState =>
       produce(state, (draft) => {
         draft.highlightMethod = payload;
+      }),
+    setPortable: (state: HighlightState, payload: boolean): HighlightState =>
+      produce(state, (draft) => {
+        draft.makeItPortable = payload;
       }),
     setIncludeSubFolders: (state: HighlightState, payload: boolean): HighlightState =>
       produce(state, (draft) => {


### PR DESCRIPTION
This pull request gives you the possibility to distribute the resulting configuration file with the replays by making the paths relative.
When the user saves a combo json somewhere, a folder called "replays" gets created in the folder of the combo json where a copy of every replay gets saved where a highlight has been found. It also forces the user to save the combo json into an empty folder for a cleaner structure (and for the zip feature).

This PR is directly related to this PR for Ishiikura for relative paths (to the json) support: https://github.com/project-slippi/Ishiiruka/pull/202.

**TODO:**

- [ ] Add ZIP functionality by asking the user at the end if he wants to compress the folder 

![image](https://user-images.githubusercontent.com/33455186/95593286-c7729e00-0a49-11eb-999c-d24062c7ee4c.png)
