### PR TITLE
Add action to execute JS scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 # yalc
 .yalc
 yalc.lock
+
+# Intellij
+.idea

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "timeago.js": "^4.0.2",
     "twitch": "^4.0.10",
     "twitch-chat-client": "^4.0.10",
-    "twitch-electron-auth-provider": "^4.0.10"
+    "twitch-electron-auth-provider": "^4.0.10",
+    "vm2": "^3.9.10"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/src/renderer/containers/actions/ActionExecuteScript.tsx
+++ b/src/renderer/containers/actions/ActionExecuteScript.tsx
@@ -1,0 +1,81 @@
+import type { ActionTypeGenerator, Context } from "@vinceau/event-actions";
+import { produce } from "immer";
+import * as React from "react";
+import { Icon } from "semantic-ui-react";
+import { NodeVM } from "vm2";
+
+import { FileInput } from "@/components/FileInput";
+import { notify as sendNotification } from "@/lib/utils";
+
+import type { ActionComponent } from "./types";
+import { readFile } from "fs-extra";
+
+interface ActionExecuteScriptParams {
+  outputFileName: string;
+}
+
+const defaultParams = (): ActionExecuteScriptParams => {
+  return {
+    outputFileName: "",
+  };
+};
+
+const executeScript: ActionTypeGenerator = (params: ActionExecuteScriptParams) => {
+  return async (ctx: Context): Promise<Context> => {
+    const { outputFileName } = params;
+
+    if (outputFileName) {
+      try {
+        const code = await readFile(outputFileName, "utf8");
+        const vm = new NodeVM({
+          require: {
+            external: true,
+          },
+          env: {
+            clippiCtx: ctx,
+          },
+        });
+
+        vm.run(code);
+      } catch (err) {
+        console.error(err);
+        sendNotification(`Failed to write to file`);
+      }
+    }
+
+    return ctx;
+  };
+};
+
+const ActionIcon = () => {
+  return <Icon name="file code" size="large" />;
+};
+
+interface ExecuteScriptProps extends Record<string, any> {
+  value: ActionExecuteScriptParams;
+  onChange(value: ActionExecuteScriptParams): void;
+}
+
+const ExecuteScriptInput = (props: ExecuteScriptProps) => {
+  const { value, onChange } = props;
+  const onOutputFileChange = (name: string) => {
+    const newValue = produce(value, (draft) => {
+      draft.outputFileName = name;
+    });
+    onChange(newValue);
+  };
+  return (
+    <div>
+      <div style={{ padding: "5px 0" }}>File:</div>
+      <FileInput value={value.outputFileName || ""} onChange={onOutputFileChange} />
+    </div>
+  );
+};
+
+export const ActionExecuteScript: ActionComponent = {
+  label: "execute script",
+  action: executeScript,
+  Icon: ActionIcon,
+  Component: ExecuteScriptInput,
+  defaultParams,
+};

--- a/src/renderer/containers/actions/index.ts
+++ b/src/renderer/containers/actions/index.ts
@@ -9,6 +9,7 @@ import { ActionToggleRecording } from "./ActionToggleRecording";
 import { ActionToggleSource } from "./ActionToggleSource";
 import { ActionTwitchClip } from "./ActionTwitchClip";
 import { ActionWriteFile } from "./ActionWriteFile";
+import { ActionExecuteScript } from "./ActionExecuteScript";
 import type { ActionComponent } from "./types";
 
 export enum Action {
@@ -20,6 +21,7 @@ export enum Action {
   WRITE_FILE = "write-file",
   SAVE_REPLAY_BUFFER = "save-replay-buffer",
   TOGGLE_RECORDING = "toggle-recording",
+  EXECUTE_SCRIPT = "execute-script",
 }
 
 export interface EventActionConfig {
@@ -46,6 +48,7 @@ export const actionComponents: { [name: string]: ActionComponent } = {
   [Action.TOGGLE_SOURCE]: ActionToggleSource,
   [Action.SAVE_REPLAY_BUFFER]: ActionSaveReplayBuffer,
   [Action.TOGGLE_RECORDING]: ActionToggleRecording,
+  [Action.EXECUTE_SCRIPT]: ActionExecuteScript,
 };
 
 for (const [key, value] of Object.entries(actionComponents)) {

--- a/src/renderer/lib/realtime.ts
+++ b/src/renderer/lib/realtime.ts
@@ -23,7 +23,7 @@ class SlpStreamManager {
     this.realtime = new SlpRealTime();
     this.eventManager = new EventManager(this.realtime);
     this.eventManager.events$.subscribe((event) => {
-      eventActionManager.emitEvent(event.id);
+      eventActionManager.emitEvent(event.id, event);
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
@@ -1859,6 +1864,11 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.7.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -10304,6 +10314,14 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vm2@^3.9.10:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.10.tgz#c66543096b5c44c8861a6465805c23c7cc996a44"
+  integrity sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
I needed a way to execute some code when a combo occured. This adds a simple action, that allows you to select a .js file, and then executes it, passing it the data from the event that triggered it.

- Add action to execute JS scripts (adds dependency on VM2)
- Include event data on emitEvent
- Add .idea folder to .gitignore