### PR TITLE
fix: Linux EPIPE errors on main

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,9 +18,13 @@ import { resolveHtmlPath } from "./util";
 import { setupIPC } from "./mainIpc";
 import { setupListeners } from "./listeners";
 
+// Prevent EPIPE errors on Linux when stdout pipe is closed during shutdown
+process.on("SIGPIPE", () => {});
+
 class AppUpdater {
   constructor() {
     log.transports.file.level = "info";
+    log.transports.console.level = "info";
     autoUpdater.logger = log;
     autoUpdater.checkForUpdatesAndNotify();
   }
@@ -146,6 +150,10 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
   }
+});
+
+app.on("before-quit", () => {
+  log.transports.console.level = false;
 });
 
 app


### PR DESCRIPTION
## Description

Fixes #195 — JavaScript EPIPE crash in the main process on Linux.

On Linux (Fedora 44 with AppImage), the app crashes with `write EPIPE at afterWriteDispatched` when the stdout pipe is closed during shutdown and subsequent writes hit the broken pipe.

### Root cause

The `EPIPE` error occurs when `electron-log`'s console transport (or direct `console.log`/`console.error` calls) writes to `process.stdout` after the reading end of the pipe has been closed. Three factors contributed:

1. `electron-log`'s console transport was left at its default `"silly"` level, passing every log call to stdout
2. No `SIGPIPE` handler was registered, so EPIPE surfaced as an uncaught exception
3. No graceful shutdown logic disabled console logging when the app quits

### Changes

1. **Ignore SIGPIPE** — Added `process.on("SIGPIPE", () => {})` to silently handle closed-pipe signals on POSIX systems.
2. **Raise console log level** — Set `log.transports.console.level` to `"info"` so debug/silly messages aren't written to stdout.
3. **Graceful shutdown** — Added a `before-quit` handler that disables the console transport entirely, preventing any log writes during the quit sequence from hitting a closed pipe.
